### PR TITLE
Include a reference systemd.service file

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ For a more lightweight, and scriptable alternative, there is
 [spotifyd-http](https://github.com/Spotifyd/spotifyd-http), which is a work in
 progress but already supports basic tasks.
 
+## Running as a systemd service
+
+A systemd.service unit file is provided to help run spotifyd as a service on
+systemd-based systems. The file `contrib/spotifyd.service` should be copied to
+either:
+
+    cd /etc/systemd/user/
+    cd ~/.config/systemd/user/
+
+Packagers of systemd-based distributions are encouraged to include the file in
+the former location. End-user should prefer the latter.
+
+Control of the daemon is then done via systemd. The following example commands
+will run the service once, and enable the service to always run on login in the
+future, respectively:
+
+    systemctl --user start spotify.service
+    systemctl --user enable spotify.service
+
 # Logging
 In `--no-daemon` mode, the log is written to standard output, otherwise it is
 written to syslog, and where it's written can be configured in your system

--- a/contrib/spotifyd.service
+++ b/contrib/spotifyd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=A spotify playing daemon
+Documentation=https://github.com/Spotifyd/spotifyd
+
+[Service]
+ExecStart=/usr/bin/spotifyd --no-daemon
+Restart=always
+RestartSec=12
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This should be used for downstream packagers in general, but should also help those manually installing easily set this up to run automatically on systemd-based distributions.

Of course, this won't affect other distributions, nor will it limit current functionality in any way.

Let me know if any bit need clarification.