### PR TITLE
Add wiki link for detailed install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ should run on any Raspberry Pi model. The binaries can be found
 have to build from source for now. You will need the ALSA package for your
 distribution, e.g. libasound2-dev on Ubuntu.
 
+Detailed install instructions can be found on the [wiki](https://github.com/Spotifyd/spotifyd/wiki).
+
 ## Build from source
 The [Rust compiler and Cargo package](https://www.rust-lang.org/en-US/)
  manager are needed:


### PR DESCRIPTION
Add sentence with link to the wiki for more detailed install instructions.

I also created 2 wiki pages with install instructions for Ubuntu and Raspberry Pi.