### PR TITLE
Make the alsa backend optional and add support for the portaudio backend to enable OSX support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -754,6 +759,7 @@ dependencies = [
  "librespot-core 0.1.0 (git+https://github.com/librespot-org/librespot.git)",
  "librespot-metadata 0.1.0 (git+https://github.com/librespot-org/librespot.git)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "portaudio-rs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1062,6 +1068,25 @@ dependencies = [
 name = "pkg-config"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "portaudio-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "portaudio-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "portaudio-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -2019,6 +2044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum base64 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9263aa6a38da271eec5c91a83ce1e800f093c8535788d403d626d8d5c3f8f007"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
+"checksum bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32866f4d103c4e438b1db1158aa1b1a80ee078e5d77a59a2f906fd62a577389c"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
@@ -2121,6 +2147,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum phf_generator 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "05a079dd052e7b674d21cb31cbb6c05efd56a2cd2827db7692e2f1a507ebd998"
 "checksum phf_shared 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c2261d544c2bb6aa3b10022b0be371b9c7c64f762ef28c6f5d4f1ef6d97b5930"
 "checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
+"checksum portaudio-rs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "029e0ab393b44b2d825efbc755cae51c36be7a99d91356b2052be0ed05836636"
+"checksum portaudio-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5194a4fa953b4ffd851c320ef6f0484cd7278cb7169ea9d6c433e49b23f7b7f5"
 "checksum proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a45f2f0ae0b5757f6fe9e68745ba25f5246aea3598984ed81d013865873c1f84"
 "checksum protobuf 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "809f3d3da85549d8292c24c767668beba458f8d6624fdad87df679f54a7d141a"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,14 @@ tokio-core = "0.1"
 tokio-signal = "0.1"
 tokio-io = "0.1"
 hostname = "0.1"
-alsa = "0.2"
 rust-crypto = "0.2.36"
 dbus = { version = "0.6", optional = true }
 dbus-tokio = { version = "0.2", optional = true }
 rspotify = "0.1.2"
 chrono = "0.4"
+
+[target.'cfg(linux)'.dependencies]
+alsa = "0.2"
 
 [replace]
 "rust-crypto:0.2.36" = { git = "https://github.com/awmath/rust-crypto.git", branch = "avx2" }
@@ -35,5 +37,6 @@ features = ["with-tremor"]
 [features]
 alsa_backend = ["librespot/alsa-backend"]
 pulseaudio_backend = ["librespot/pulseaudio-backend"]
+portaudio_backend = ["librespot/portaudio-backend"]
 dbus_mpris = ["dbus", "dbus-tokio"]
 default = ["alsa_backend"]

--- a/README.md
+++ b/README.md
@@ -68,13 +68,25 @@ no-daemon mode, among other things.
 ## Audio Backend
 By default, the audio backend is ALSA, as ALSA is available by default on a lot
 of machines and requires no extra dependencies. There is also support for
-`pulseaudio`. To use PulseAudio, compile with the `--features` flag to enable
+`pulseaudio` and `portaudio`. 
+
+### PulseAudio
+To use PulseAudio, compile with the `--features` flag to enable
 it:
 ```
 cargo build --release --features pulseaudio_backend
 ```
 You will need the development package for PulseAudio, as well
 as `build-essential` or the equivalent in your distribution.
+
+### PortAudio
+To use PortAudio (works on OSX), compile with the `--features` flag to enable it:
+```
+cargo build --release --no-default-features --features portaudio_backend
+```
+You will need the development package for PortAudio (`brew install portaudio`), as well
+as `build-essential` or the equivalent in your distribution.
+
 
 # Usage
 Spotifyd communicates over the Spotify Connect protocol, meaning that it can be

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "alsa_backend")]
 extern crate alsa;
 extern crate chrono;
 extern crate crypto;
@@ -32,6 +33,7 @@ use tokio_core::reactor::Core;
 
 mod config;
 mod cli;
+#[cfg(feature = "alsa_backend")]
 mod alsa_mixer;
 mod main_loop;
 mod setup;


### PR DESCRIPTION
fixes #129 

I have no doubt there is a cleaner way to separate out all of the alsa logic without the need for conditional compilation. However I don't know any rust (yet) so this was just an attempt to prove that spotifyd will actually compile and run on OSX. If you have any tips on a cleaner way to implement this I would love some pointers in the right direction. 

