### PR TITLE
Add dependencies to the spotifyd systemd service

### DIFF
--- a/contrib/spotifyd.service
+++ b/contrib/spotifyd.service
@@ -1,6 +1,10 @@
 [Unit]
 Description=A spotify playing daemon
 Documentation=https://github.com/Spotifyd/spotifyd
+Wants=sound.target
+After=sound.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=/usr/bin/spotifyd --no-daemon


### PR DESCRIPTION
Spotifyd crashes if it starts before either the sound card is configured or the network is available. Whilst this is not too bad, it causes a restart of the service when started at boot. It is nicer to just depend on the targets that systemd provides to signal availability of both.