### PR TITLE
Use port 443 instead of 80

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -78,7 +78,7 @@ impl Default for SpotifydConfig {
                 user_agent: version::version_string(),
                 device_id: device_id("Spotifyd"),
                 proxy: None,
-                ap_port: Some(80),
+                ap_port: Some(443),
             },
             onevent: None,
         }


### PR DESCRIPTION
Some networks block Spotify Connect, probably using some simple packet inspection. Switching to port 443 fixes this, at least for me.