### PR TITLE
Create snapcraft.yaml to enable building of snaps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,42 @@
+name: spotifyd
+adopt-info: spotifyd
+summary: A spotify daemon
+description: |
+  An open source Spotify client running as a UNIX daemon. 
+  Spotifyd streams music just like the official client, 
+  but is more lightweight and supports more platforms. 
+  Spotifyd also supports the Spotify Connect protocol 
+  which makes it show up as a device that can be controlled 
+  from the official clients.
+  Spotifyd requires a Spotify Premium account
+
+grade: stable
+confinement: strict
+
+parts:
+  spotifyd:
+    plugin: rust
+    rust-channel: nightly
+    source: https://github.com/Spotifyd/spotifyd.git
+    rust-features: ["pulseaudio_backend"]
+    build-packages:
+      - libssl-dev
+      - libasound2-dev
+      - libpulse-dev
+      - pkg-config
+    stage-packages:
+      - libpulse0
+    override-build: |
+      snapcraftctl build
+      snapcraftctl set-version $(git describe --tags)
+
+apps:
+  spotifyd:
+    environment:
+      LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio"
+    command: bin/spotifyd 
+    daemon: forking
+    plugs:
+      - network
+      - network-bind
+      - pulseaudio


### PR DESCRIPTION
As discussed over mail, this is a pull request to add support for building snaps.

A single snap (built for many architectures) in the Snap Store will be installable on numerous popular Linux distributions with no changes. It’ll also be discoverable via the [Snap Store](https://snapcraft.io/store), where releases are under your control.

If you're willing to publish this under the spotifyd project name, you just need to [create an account](https://snapcraft.io/snaps) and then [register the spotifyd name](https://snapcraft.io/register-snap).

A snap file created by snapcraft (our free software tool for building snaps) can then be released in the Snap Store with `snap push --release stable *.snap`. You'll want to install snapcraft (brew install snapcraft, snap install snapcraft, or apt install snapcraft) and login (snapcraft login) first, though.

You may also want to consider using [https://build.snapcraft.io/](https://build.snapcraft.io/) which is a free build service, that can create armhf, amd64, i386, arm64 and other builds of spotifyd, and push them to the store automatically. Alternatively it’s possible to integrate publishing the snap via your existing travis CI / release process.

I appreciate you may not be aware of snaps and snapcraft, and I’d of course be happy to answer any questions you may have. 

This snap will be strictly confined, only able to access the network and the pulseaudio sound server. I have enabled the pulseaudio backend and in documentation for the snap would recommend using that backend exclusively as alsa can be problematic in snaps. We can certainly investigate enabling alsa support in the snap if desired at a later date.

I have set the snap to be a daemon, so it will automatically start on install. As it’s strictly confined it will look in ~/snap/spotifyd/current (the home directory) for .config/spotifyd/spotifyd.conf - So the full path to the config file used by the snap is /root/snap/spotifyd/current/.config/spotifyd.conf . I have tested this and once the configuration file is in place and the snap restarted, all works as expected.
