### PR TITLE
Update to add logic to build stable releases

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ parts:
   spotifyd:
     plugin: rust
     rust-channel: nightly
-    source: https://github.com/Spotifyd/spotifyd.git
+    source: .
     rust-features: ["pulseaudio_backend"]
     build-packages:
       - libssl-dev
@@ -26,9 +26,18 @@ parts:
       - pkg-config
     stage-packages:
       - libpulse0
-    override-build: |
-      snapcraftctl build
-      snapcraftctl set-version $(git describe --tags)
+    override-pull: |
+      snapcraftctl pull
+      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"
+      last_released_tag="$(snap info spotifyd | awk '$1 == "beta:" { print $2 }')"
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${last_committed_tag_ver}" != "${last_released_tag}" ]; then
+        git fetch
+        git checkout "${last_committed_tag}"
+      fi
+      snapcraftctl set-version "$(git describe --tags | sed 's/v//')"
 
 apps:
   spotifyd:


### PR DESCRIPTION
This makes it easier to build stable releases.
This relies on you keeping a stable release in the beta channel in the store. Clearly you can also have the same stable release in the stable channel.
On every build the `override-pull` section will query the store to see what version is in the beta channel. If it's older the the current tagged release in github, we checkout the latest release, build that.
So, to prepare, leave the beta channel empty. Merge this branch and the next build will see the beta channel is empty, and choose to build the most recent tagged release. 
Once built, you can release that to the beta channel (and once tested) release also to the stable channel.
From this point onwards any changes in master will trigger a built of the tip as there isn't a newer tagged release than what is in the beta channel. 
When you next do a tagged release, the next snap build will be based on that release which you can again test and push to stable.

Further, you may get a notification from the store telling you there's a security update in one of your dependencies (of which you have few, so this is unlikely). To re-build the most recent stable release, simply close the beta channel (which you can do in the store web UI or via 'snapcraft close spotifyd beta`) and trigger a build on build.snapcraft.io. You'll get a re-build of the most recent tagged release, using the latest rust toolchain and dependencies.

So going forward you'll have stable releases in stable (and beta) channels. Bleeding edge builds will be in 'edge' which users can opt into testing. You can even suggest users install from edge to test out bug fixes.

I hope that all makes sense. I have been using this method for a year or so in the snapcrafters repo where we host a bunch of snaps, and it works quite well. 

