### PR TITLE
Use config in /etc for systemd service

### DIFF
--- a/contrib/spotifyd.service
+++ b/contrib/spotifyd.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/usr/bin/spotifyd --no-daemon
+ExecStart=/usr/bin/spotifyd --no-daemon --config /etc/spotifyd.conf
 Restart=always
 RestartSec=12
 


### PR DESCRIPTION
Even though it is a user service, it is still recommended to load the configuration from a central configuration place. A configuration file is a must have for a service, you should not edit the service file itself.

I am also working on a system wide service that works on embedded systems with no user logged in. I am trying to get this working properly first, so it feels better integrated and not so 'hacky'. The user service is the correct option for now, especially when running a normal desktop environment at the same time.