### PR TITLE
Replace rust-crypto with sha-1 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "rust-crypto"
 version = "0.2.36"
-source = "git+https://github.com/awmath/rust-crypto.git?branch=avx2#394c247254dbe2ac5d44483232cf335d10cf0260"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1937,12 +1937,6 @@ dependencies = [
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "rust-crypto"
-version = "0.2.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-replace = "rust-crypto 0.2.36 (git+https://github.com/awmath/rust-crypto.git?branch=avx2)"
 
 [[package]]
 name = "rust-gmp"
@@ -2202,13 +2196,14 @@ dependencies = [
  "dbus-tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "keyring 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "librespot 0.1.0 (git+https://github.com/librespot-org/librespot.git)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rspotify 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-ini 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3099,7 +3094,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rpassword 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ec4bdede957362ec6fdd550f7e79c6d14cad2bc26b2d062786234c6ee0cb27bb"
 "checksum rpassword 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37473170aedbe66ffa3ad3726939ba677d83c646ad4fd99e5b4bc38712f45ec"
 "checksum rspotify 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "dee05e47d9aed6b35d9666d80c6b0d4d7ca6253e7a88464410a85dba1a8cd63d"
-"checksum rust-crypto 0.2.36 (git+https://github.com/awmath/rust-crypto.git?branch=avx2)" = "<none>"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rust-gmp 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4cd7d57377b309a73f69e164109203aa9ab3fee6ea68ac5fb76e2edb50662e9b"
 "checksum rust-ini 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ hostname = "0.1"
 keyring = { version = "0.6.1", optional = true }
 log = "0.4.6"
 rspotify = "0.2.5"
-rust-crypto = "0.2.36"
+sha-1 = "0.8"
+hex = "0.3"
 rust-ini = "0.13"
 simplelog = "0.4"
 syslog = "4.0.1"
@@ -29,9 +30,6 @@ xdg = "2.2"
 default-features = false
 features = ["with-tremor"]
 git = "https://github.com/librespot-org/librespot.git"
-
-[replace]
-"rust-crypto:0.2.36" = { git = "https://github.com/awmath/rust-crypto.git", branch = "avx2" }
 
 [features]
 alsa_backend = ["librespot/alsa-backend", "alsa"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use sha1::{Sha1, Digest};
 use getopts::Matches;
 use hostname;
 use ini::Ini;
@@ -7,6 +6,7 @@ use librespot::{
     playback::config::{Bitrate, PlayerConfig},
 };
 use log::info;
+use sha1::{Digest, Sha1};
 use std::{
     convert::From,
     error::Error,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crypto::{digest::Digest, sha1::Sha1};
+use sha1::{Sha1, Digest};
 use getopts::Matches;
 use hostname;
 use ini::Ini;
@@ -25,9 +25,7 @@ pub enum VolumeController {
 }
 
 fn device_id(name: &str) -> String {
-    let mut h = Sha1::new();
-    h.input_str(name);
-    h.result_str()
+    hex::encode(&Sha1::digest(name.as_bytes()))
 }
 
 impl FromStr for VolumeController {


### PR DESCRIPTION
You don't need the whole rust-crypto for just SHA-1. Also see librespot-org/librespot#239.
