### PR TITLE
Move to 2018 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,9 @@ dependencies = [
 name = "error-chain"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "extprim"
@@ -1945,12 +1948,12 @@ dependencies = [
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "librespot 0.1.0 (git+https://github.com/librespot-org/librespot.git)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rspotify 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-ini 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "syslog 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2008,13 +2011,13 @@ dependencies = [
 
 [[package]]
 name = "syslog"
-version = "3.3.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2439,15 +2442,6 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "unix_socket"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "unreachable"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,7 +2816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
-"checksum syslog 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bbc9b0acde4f7c05fdc1cfb05239b8a53a66815dd86c67fee5aa9bfac5b4ed42"
+"checksum syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a0641142b4081d3d44beffa4eefd7346a228cdf91ed70186db2ca2cef762d327"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ce2fe9db64b842314052e2421ac61a73ce41b898dc8e3750398b219c5fc1e0"
 "checksum tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2"
@@ -2863,7 +2857,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ xdg = "2.1"
 ctrlc = { version = "3.1", features = ["termination"] }
 rust-ini = "0.10"
 getopts = "0.2"
-log = "0.3"
-syslog = "3.3"
+log = "0.4.6"
+syslog = "4.0.1"
 daemonize = "0.3"
 futures = "0.1"
 tokio-core = "0.1"
@@ -25,13 +25,13 @@ rspotify = "0.2.5"
 chrono = "0.4"
 alsa = { version = "0.2", optional = true }
 
-[replace]
-"rust-crypto:0.2.36" = { git = "https://github.com/awmath/rust-crypto.git", branch = "avx2" }
-
 [dependencies.librespot]
 git = "https://github.com/librespot-org/librespot.git"
 default-features = false
 features = ["with-tremor"]
+
+[replace]
+"rust-crypto:0.2.36" = { git = "https://github.com/awmath/rust-crypto.git", branch = "avx2" }
 
 [features]
 alsa_backend = ["librespot/alsa-backend", "alsa"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spotifyd"
 version = "0.2.6"
 authors = ["Simon Persson <simon@flaskpost.org>"]
+edition = "2018"
 
 [dependencies]
 simplelog = "0.4"

--- a/src/alsa_mixer.rs
+++ b/src/alsa_mixer.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use librespot::playback::mixer::{AudioFilter, Mixer};
 use alsa;
+use log::error;
 
 pub struct AlsaMixer {
     pub device: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ use librespot::core::version;
 use xdg;
 use ini::Ini;
 use getopts::Matches;
+use log::info;
 
 use hostname;
 
@@ -87,7 +88,7 @@ impl Default for SpotifydConfig {
 
 pub fn get_config_file() -> Result<PathBuf, Box<Error>> {
     let etc_conf = format!("/etc/{}", CONFIG_FILE);
-    let xdg_dirs = try!(xdg::BaseDirectories::with_prefix("spotifyd"));
+    let xdg_dirs = xdg::BaseDirectories::with_prefix("spotifyd")?;
     xdg_dirs
         .find_config_file(CONFIG_FILE)
         .or_else(|| {

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -19,6 +19,7 @@ use rspotify::spotify::client::Spotify;
 use rspotify::spotify::senum::*;
 use futures::{Async, Future, Poll, Stream};
 use futures::sync::oneshot;
+use log::{info, warn};
 
 pub struct DbusServer {
     session: Session,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,34 +1,10 @@
-#[cfg(feature = "alsa_backend")]
-extern crate alsa;
-extern crate chrono;
-extern crate crypto;
-extern crate daemonize;
-#[cfg(feature = "dbus_mpris")]
-extern crate dbus;
-#[cfg(feature = "dbus_mpris")]
-extern crate dbus_tokio;
-extern crate futures;
-extern crate getopts;
-extern crate hostname;
-extern crate ini;
-extern crate librespot;
-#[macro_use]
-extern crate log;
-#[cfg(feature = "dbus_mpris")]
-extern crate rspotify;
-extern crate simplelog;
-extern crate syslog;
-extern crate tokio_core;
-extern crate tokio_io;
-extern crate tokio_signal;
-extern crate xdg;
-
 use std::process::exit;
 use std::panic;
 use std::convert::From;
 use std::error::Error;
 
 use daemonize::Daemonize;
+use log::{error, info, LevelFilter};
 use tokio_core::reactor::Core;
 
 mod config;
@@ -86,9 +62,9 @@ fn main() {
             .expect("Couldn't initialize logger");
     } else {
         let filter = if matches.opt_present("verbose") {
-            log::LogLevelFilter::Trace
+            LevelFilter::Trace
         } else {
-            log::LogLevelFilter::Info
+            LevelFilter::Info
         };
         syslog::init(syslog::Facility::LOG_DAEMON, filter, Some("Spotifyd"))
             .expect("Couldn't initialize logger");

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -16,7 +16,7 @@ use librespot::core::cache::Cache;
 use librespot::core::config::{ConnectConfig, DeviceType};
 
 #[cfg(feature = "dbus_mpris")]
-use dbus_mpris::DbusServer;
+use crate::dbus_mpris::DbusServer;
 
 use tokio_core::reactor::Handle;
 use tokio_io::IoStream;

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -21,7 +21,7 @@ use dbus_mpris::DbusServer;
 use tokio_core::reactor::Handle;
 use tokio_io::IoStream;
 
-use player_event_handler::run_program_on_events;
+use crate::player_event_handler::run_program_on_events;
 
 pub struct LibreSpotConnection {
     connection: Box<Future<Item = Session, Error = io::Error>>,

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::process::{Child, Command};
 use librespot::playback::player::PlayerEvent;
+use log::info;
 
 fn run_program(program: &str, env_vars: HashMap<&str, String>) -> Child {
     let mut v: Vec<&str> = program.split_whitespace().collect();

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -13,11 +13,12 @@ use librespot::core::cache::Cache;
 use librespot::playback::audio_backend::{Sink, BACKENDS};
 use futures::Future;
 use getopts::Matches;
-use config;
+use crate::config;
 #[cfg(feature = "alsa_backend")]
-use alsa_mixer;
+use crate::alsa_mixer;
 use futures;
-use main_loop;
+use crate::main_loop;
+use log::{error, info};
 
 pub fn initial_state(handle: Handle, matches: &Matches) -> main_loop::MainLoopState {
     let config_file = matches


### PR DESCRIPTION
This PR moves partial source code to the 2018 edition of Rust.

API wise, this won't change much. The 2018 edition improved the way how Rust code gets imported. Instead of having to write a huge chunk of `extern crate ...` statements, the code gets now pulled in as soon as someone declares its usage via `use ...`. The change introduced a new keyword too, `crate`, that is used to refer to the crate's own modules.

To make use of the 2018edition I had to upgrade the `syslog` and `log` crates. Those changed their API from `LogLevelFilter` to `LevelFilter` and I changed those two lines accordingly. 

Besides that, the 2018 edition introduced a new operator, the `?`. This one basically is the old `try!` macro you used in some part of the code. The team behind Rust decided to give it its own operator as it has been used extensively by the community and them.

I've build every feature available locally to make sure that everything still compiles. I didn't change any logic whatsoever in this PR so the daemon will work as expected.