### PR TITLE
Add missing `store` keyword in secret-tool command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ To add such an entry, you can use `secret-tool`, a CLI used to communicate with 
 that support the Linux Secret Service API:
 
 ```
-$ secret-tool --label='entry name that you can choose' application rust-keyring service spotifyd username <your-username>
+$ secret-tool store --label='entry name that you can choose' application rust-keyring service spotifyd username <your-username>
 ```
 
 ## Command Line Arguments


### PR DESCRIPTION
Previously, the command would fail with error code 2 and display the following
usage description:

```
usage: secret-tool store --label='label' attribute value ...
       secret-tool lookup attribute value ...
       secret-tool clear attribute value ...
       secret-tool search [--all] [--unlock] attribute value ...
```