### PR TITLE
mpris: SupportedUriSchemes has `as` type in spec

### DIFF
--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -437,10 +437,10 @@ fn create_dbus_server(
                             }),
                     )
                     .add_p(
-                        f.property::<String, _>("SupportedUriSchemes", ())
+                        f.property::<Vec<String>, _>("SupportedUriSchemes", ())
                             .access(Access::Read)
                             .on_get(|i, _| {
-                                i.append("Spotify".to_string());
+                                i.append(vec!["Spotify".to_string()]);
                                 Ok(())
                             }),
                     ),


### PR DESCRIPTION
The mpris specification dictates that SupportedUriSchemes should be an array of strings.

This fixes #240.

---

Type is correct in D-Feet after the changes made in this branch.

![Skärmbild från 2019-04-20 21-17-53](https://user-images.githubusercontent.com/1599/56461374-1dfd9f80-63b2-11e9-848f-e2503b83b14e.png)
