### PR TITLE
Separate config option for control (i.e. mixer) device

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ password = PASS
 #use-keyring = true
 backend = alsa
 device = alsa_audio_device # Given by `aplay -L`
+#control = alsa_audio_device # device for the mixer, if not the same as 'device'
 mixer = PCM
 volume-control = alsa # or alsa_linear, or softvol
 #onevent = command_run_on_playback_event

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,6 +19,7 @@ pub fn command_line_argument_options() -> Options {
     opts.optopt("u", "username", "Spotify user name.", "USERNAME");
     opts.optopt("p", "password", "Spotify password.", "PASSWORD");
     opts.optopt("", "device", "Audio device, given by aplay -L.", "DEVICE");
+    opts.optopt("", "control", "Mixer device, if not the same as 'device'.", "DEVICE");
     opts.optopt("", "mixer", "Audio mixer", "DEVICE");
     opts.optopt("", "bitrate", "Any of 96, 160, and 320.", "DEVICE");
     opts.optopt("", "pid", "Path to PID file.", "PID-FILE");

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,7 @@ pub struct SpotifydConfig {
     pub cache: Option<Cache>,
     pub backend: Option<String>,
     pub audio_device: Option<String>,
+    pub control_device: Option<String>,
     pub mixer: Option<String>,
     pub volume_controller: VolumeController,
     pub device_name: String,
@@ -66,6 +67,7 @@ impl Default for SpotifydConfig {
             cache: None,
             backend: None,
             audio_device: None,
+            control_device: None,
             mixer: None,
             volume_controller: VolumeController::SoftVol,
             device_name: "Spotifyd".to_string(),
@@ -159,6 +161,7 @@ pub fn get_config<P: AsRef<Path>>(config_path: Option<P>, matches: &Matches) -> 
     }
     config.backend = lookup("backend");
     config.audio_device = lookup("device");
+    config.control_device = lookup("control");
     config.mixer = lookup("mixer");
     update(
         &mut config.volume_controller,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -24,6 +24,7 @@ use tokio_signal::ctrl_c;
 
 pub fn initial_state(handle: Handle, config: config::SpotifydConfig) -> main_loop::MainLoopState {
     let local_audio_device = config.audio_device.clone();
+    let local_control_device = config.control_device.clone();
     let local_mixer = config.mixer.clone();
 
     #[cfg(feature = "alsa_backend")]
@@ -32,8 +33,9 @@ pub fn initial_state(handle: Handle, config: config::SpotifydConfig) -> main_loo
             info!("Using alsa volume controller.");
             Box::new(move || {
                 Box::new(alsa_mixer::AlsaMixer {
-                    device: local_audio_device
+                    device: local_control_device
                         .clone()
+                        .or_else(|| local_audio_device.clone())
                         .unwrap_or_else(|| "default".to_string()),
                     mixer: local_mixer.clone().unwrap_or_else(|| "Master".to_string()),
                     linear_scaling: linear,


### PR DESCRIPTION
See #87.

I'm very happy to change option name, description, etc. and be corrected on my rusty rust. I just found this useful and wanted to share.