### PR TITLE
Enable clippy, rustfmt and pulseaudio for x86

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
           - libc6-dev-armhf-cross
           - libasound2-dev
           - libssl-dev
+          - libdbus-1-dev
+          - portaudio19-dev
       before_script:
       - echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ xenial main" | sudo tee -a /etc/apt/sources.list
       - sudo apt-get update
@@ -35,7 +37,6 @@ matrix:
       - dpkg -x libssl-dev*.deb $TRAVIS_BUILD_DIR/deps_root/
       - dpkg -x libssl1.0.0*.deb $TRAVIS_BUILD_DIR/deps_root/
       - dpkg -x libasound2-dev*.deb $TRAVIS_BUILD_DIR/deps_root/
-
     - name: "x86 Build"
       env:
       - TARGET=x86_64-unknown-linux-gnu
@@ -47,7 +48,7 @@ matrix:
           - libssl-dev
           - libpulse-dev
           - libdbus-1-dev
-            
+          - portaudio19-dev        
 script:
 - rustup component add clippy
 - rustup component add rustfmt
@@ -57,7 +58,7 @@ script:
 - cargo build --target=$TARGET --release
 - zip -j spotifyd-`date --iso-8601`-$SHORT_TARGET-slim.zip target/$TARGET/release/spotifyd
 - if [ $SHORT_TARGET = "x86" ]; then cargo build --target=$TARGET --release --features "pulseaudio_backend"; fi
-- if [ $SHORT_TARGET = "x86" ]; then zip -j spotifyd-`date --iso-8601`-$SHORT_TARGET-pulseaudio.zip target/$TARGET/release/spotifyd
+- if [ $SHORT_TARGET = "x86" ]; then zip -j spotifyd-`date --iso-8601`-$SHORT_TARGET-pulseaudio.zip target/$TARGET/release/spotifyd; fi
 
 #deploy:
 #  provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: rust
 cache: cargo
-rust:
-- stable
+rust: stable
 sudo: required
-os:
-- linux
+os: linux
+dist: xenial
 
 matrix:
   include:
@@ -25,9 +24,8 @@ matrix:
           - libc6-dev-armhf-cross
           - libasound2-dev
           - libssl-dev
-          - libssl1.0.0
       before_script:
-      - echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ trusty main" | sudo tee -a /etc/apt/sources.list
+      - echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ xenial main" | sudo tee -a /etc/apt/sources.list
       - sudo apt-get update
       - sudo apt-get download libasound2:armhf
       - sudo apt-get download libasound2-dev:armhf
@@ -47,20 +45,27 @@ matrix:
           packages:
           - libasound2-dev
           - libssl-dev
-          - libssl1.0.0      
+          - libpulse-dev
+          - libdbus-1-dev
             
 script:
+- rustup component add clippy
+- rustup component add rustfmt
+- RUSTFLAGS="" cargo clippy --all-features --all-targets -- -D warnings
+- cargo fmt -- --check
 - rustup target add $TARGET
 - cargo build --target=$TARGET --release
-- zip -j spotifyd-`date --iso-8601`-$SHORT_TARGET.zip target/$TARGET/release/spotifyd
+- zip -j spotifyd-`date --iso-8601`-$SHORT_TARGET-slim.zip target/$TARGET/release/spotifyd
+- if [ $SHORT_TARGET = "x86" ]; then cargo build --target=$TARGET --release --features "pulseaudio_backend"; fi
+- if [ $SHORT_TARGET = "x86" ]; then zip -j spotifyd-`date --iso-8601`-$SHORT_TARGET-pulseaudio.zip target/$TARGET/release/spotifyd
 
-deploy:
-  provider: releases
-  api_key:
-    secure: TwIv65LDHIBOgOsafV/wio+EwoG0pg5sFZZvEgNIV5J++zJoxaI35DH1/frKB6S4J2HhEKDojc7Np4tEgNUCOj+qZ51ma85SYr3SzVOg2n/TUI7lg/Gb13n6qd1AfTA2SsTryuGIvS7p4BaYSRtGXUuOghZg+7qdgl+zKeXiLnY=
-  file_glob: true
-  file: "spotifyd*zip"
-  skip_cleanup: true
-  on:
-    branch: master
-    tags: true
+#deploy:
+#  provider: releases
+#  api_key:
+#    secure: TwIv65LDHIBOgOsafV/wio+EwoG0pg5sFZZvEgNIV5J++zJoxaI35DH1/frKB6S4J2HhEKDojc7Np4tEgNUCOj+qZ51ma85SYr3SzVOg2n/TUI7lg/Gb13n6qd1AfTA2SsTryuGIvS7p4BaYSRtGXUuOghZg+7qdgl+zKeXiLnY=
+#  file_glob: true
+#  file: "spotifyd*zip"
+#  skip_cleanup: true
+#  on:
+#    branch: master
+#    tags: true


### PR DESCRIPTION
I reenabled clippy and rustfmt. i had no success in enabling pulseaudio for both architectures. so i left it only for x86.