### PR TITLE
Improve english on cache_path explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,12 @@ the `[global]` section. This is useful when you run applications related to
 Values can be surrounded by double quotes (") which is useful if the value contains
 the comment character (#).
 
-The line `cache_path = /cache_directory` defines where Spotify's cache-files are stored.
-These files are used to avoid re-downloading data when a track is replayed.
-Here it's set to `/cache_directory` and the cache files will be stored in `/cache_directory`.
-To save space on the system disc you can use another directory, for example `/mount/disk/spotifyCache`
-(which of course have to exist). The path will not be expanded by the shell. This means that paths
-like `~/` and `$HOME/` will not work. Spotifyd will not try to create a missing path, so the cache
-path must exist.
+The line `cache_path = /cache_directory` defines the cache path, where Spotify's cache-files are stored.
+These cache-files are used to avoid re-downloading data when a track is replayed.
+Here the cache path is set to store the cache-files in `/cache_directory`.
+To save space on the system disc you can use another directory, for example `/mount/disk/spotifyCache`.
+Spotifyd does not create a missing cache path, so the path must exist.
+The cache path is not expanded by the shell: paths containing e.g. `~/` or `$HOME/` will not work.
 
 Instead of storing your password in the config file, `Spotifyd` supports the
 Linux Secret Service API when compiled with the `dbus_keyring` feature. To use


### PR DESCRIPTION
Define `the cache path' and remove ambiguity, 

Remove the repetitive 'is set to A so A is used'.

`have to exist' is not english. The bracketed text can also be removed because an explanation that the path must exist follows soon after.

First explain missing path and then shell expansion.

Remove redundant 'this means that ...'.

As a followup, what would happen if a relative path is provided? Is it allowed or must the path be absolute?