### PR TITLE
refactor to use gethostname crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2280,6 +2289,7 @@ dependencies = [
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gethostname 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "keyring 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3097,6 +3107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
 "checksum get_if_addrs-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
+"checksum gethostname 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4ab273ca2a31eb6ca40b15837ccf1aa59a43c5db69ac10c542be342fae2e01d"
 "checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ dbus = { version = "0.6", optional = true }
 dbus-tokio = { version = "0.2", optional = true }
 failure = "0.1.5"
 futures = "0.1"
+gethostname = "0.2.0"
 hex = "0.3"
 keyring = { version = "0.6.1", optional = true }
 lazy_static = "1.4.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use gethostname::gethostname;
 use lazy_static::lazy_static;
 use librespot::{
     core::{cache::Cache, config::SessionConfig, version},
@@ -435,13 +436,10 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         .unwrap_or(Backend::Alsa)
         .to_string();
 
-    let device_name = config.shared_config.device_name.unwrap_or_else(|| {
-        format!(
-            "{}@{}",
-            "Spotifyd",
-            utils::get_hostname().unwrap_or_else(|| "unknown".to_string())
-        )
-    });
+    let device_name = config
+        .shared_config
+        .device_name
+        .unwrap_or_else(|| format!("{}@{}", "Spotifyd", gethostname().to_string_lossy()));
 
     let normalisation_pregain = config.shared_config.normalisation_pregain.unwrap_or(0.0f32);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,20 +9,6 @@ thread_local! {
     static BUF_USERNAME: RefCell<[libc::c_char; 255]> = RefCell::new([0; 255]);
 }
 
-pub(crate) fn get_hostname() -> Option<String> {
-    BUF_HOSTNAME.with(|refcell| {
-        let mut buf = refcell.borrow_mut();
-        let ret = unsafe { libc::gethostname(buf.as_mut_ptr() as _, buf.len() as _) };
-        if ret != 0 {
-            return None;
-        }
-        let cstr = unsafe { CStr::from_ptr(buf.as_ptr()) };
-        let hostname = cstr.to_string_lossy().to_string();
-        log::trace!("Found hostname {:?} using gethostname.", hostname);
-        Some(hostname)
-    })
-}
-
 pub(crate) fn get_shell() -> Option<String> {
     // First look for the user's preferred shell using the SHELL environment
     // variable...

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -95,8 +95,6 @@ mod tests {
 
         env_logger::init();
 
-        let _ = get_hostname().unwrap();
-
         let _ = get_shell().unwrap();
 
         if env::var("SHELL").is_ok() {


### PR DESCRIPTION
This commit moves away from the custom gethostname function and uses a well tested crate instead.

Closes #287.