### PR TITLE
fix volume_controller not having a default value

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -436,6 +436,11 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         .unwrap_or(Backend::Alsa)
         .to_string();
 
+    let volume_controller = config
+        .shared_config
+        .volume_controller
+        .unwrap_or(VolumeController::SoftVolume);
+
     let device_name = config
         .shared_config
         .device_name
@@ -475,7 +480,7 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         audio_device: config.shared_config.device,
         control_device: config.shared_config.control,
         mixer: config.shared_config.mixer,
-        volume_controller: config.shared_config.volume_controller.unwrap(),
+        volume_controller,
         device_name,
         player_config: PlayerConfig {
             bitrate,


### PR DESCRIPTION
This commit makes softvol the default volume_controller if none is specified.

Fixes #294.