### PR TITLE
add CI and CD workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,68 @@
+name: Continuous Deployment
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  publish:
+    name: Publishing for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        rust: [stable]
+        feature: [
+          '',                                             # Slim version has no features enabled by default.
+          'dbus_keyring,dbus_mpris'                       # Full version has all OS compatible features enabled
+        ]
+        artifact_type: ['slim', 'full']                   # The build strategy will build both types for each OS specified
+        include:
+          - os: macos-latest
+            artifact_prefix: macos
+            audio_backend: portaudio
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            artifact_prefix: linux
+            audio_backend: alsa
+            target: x86_64-unknown-linux-gnu
+
+    steps:
+      - name: Installing Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Installing needed macOS dependencies
+        if: matrix.os == 'macos-latest'
+        run: brew install awk dbus pkg-config portaudio
+      - name: Installing needed Ubuntu dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          ssudo apt-get install -y -qq libasound2-dev libssl-dev libpulse-dev libdbus-1-dev
+
+      - name: Checking out sources
+        uses: actions/checkout@v1
+      - name: Running cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          toolchain: ${{ matrix.rust }}
+          args: --release --target ${{ matrix.target }} --no-default-features --features "${{ matrix.feature }},${{ matrix.audio_backend }}_backend"
+      
+      - name: Packaging final binary
+        shell: bash
+        run: |
+          strip target/${{ matrix.target }}/release/spotifyd
+          tar czvf spotifyd-${{ matrix.artifact_prefix }}-${{ matrix.artifact_type }}.tar.gz target/${{ matrix.target }}/release/spotifyd
+          shasum -a 512 spotifyd-${{ matrix.artifact_prefix }}-${{ matrix.artifact_type }}.tar.gz | awk '{ print $1 }' > spotifyd-${{ matrix.artifact_prefix }}-${{ matrix.artifact_type }}.sha512
+      - name: Releasing assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            spotifyd-${{ matrix.artifact_prefix }}-${{ matrix.artifact_type }}.tar.gz
+            spotifyd-${{ matrix.artifact_prefix }}-${{ matrix.artifact_type }}.sha512
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: Continuous Integration
+
+on: [pull_request]
+
+jobs:
+  codestyle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Installing Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Checking out sources
+        uses: actions/checkout@v1
+      - name: Installing rustfmt
+        run: rustup component add rustfmt
+      - name: Running rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+    
+  lint:
+    needs: [codestyle]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Installing Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Installing needed Ubuntu dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y -qq libasound2-dev libssl-dev libpulse-dev libdbus-1-dev portaudio19-dev
+
+      - name: Checking out sources
+        uses: actions/checkout@v1
+      - name: Installing clippy
+        run: rustup component add clippy
+      - name: Linting project
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets --all-features -- -D warnings
+
+  check:
+    needs: [lint]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        include:
+          - os: macos-latest
+            features: portaudio_backend,dbus_keyring
+          - os: ubuntu-latest
+            features: alsa_backend,dbus_keyring,dbus_mpris
+
+    steps:
+      - name: Installing Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Installing macOS dependencies
+        if: matrix.os == 'macos-latest'
+        run: brew install pkg-config portaudio
+      - name: Installing needed Ubuntu dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y -qq libasound2-dev libssl-dev libpulse-dev libdbus-1-dev
+      
+      - name: Checking out sources
+        uses: actions/checkout@v1
+      - name: Checking Rust code
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features --features ${{ matrix.features }}


### PR DESCRIPTION
This commit adds a CI workflow to the project. It checks for the correct code style (using cargo fmt) and lints the whole project as well (using cargo clippy). The last step checks if the binary can be compiled on our target OS (using cargo check).

The commit also adds a workflow for CD. After each release, the workflow will build binaries for both Linux and macOS in two flavours: slim and full. Slim does contain nothing but the proper audio backend. Full contains all features that work correctly on the specific platform. For Linux that is dbus_keyring and dbus_mpris. For macOS it is only dbus_keyring. The resulting binaries are compressed into a .tar.gz archive and uploaded as assets to the appropiate release. The script does also create sha512 checksums and uploads them as well.

Closes #281.