### PR TITLE
fix spotify connect deviceid

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -477,6 +477,8 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         .device_name
         .unwrap_or_else(|| format!("{}@{}", "Spotifyd", gethostname().to_string_lossy()));
 
+    let device_id = device_id(&device_name);
+
     let normalisation_pregain = config.shared_config.normalisation_pregain.unwrap_or(0.0f32);
 
     let pid = config
@@ -520,7 +522,7 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         },
         session_config: SessionConfig {
             user_agent: version::version_string(),
-            device_id: device_id("Spotifyd"),
+            device_id,
             proxy: None,
             ap_port: Some(443),
         },


### PR DESCRIPTION
This commit fixes a bug where running multiple daemons on the same account wouldn\'t work as each of them is externally seen as the same device by spotify's connect api. The reason was that the deviceid was static within the code instead of using the device_name property.

Fixes #332. 