### PR TITLE
fix pid cli flag expecting wrong type

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -187,9 +187,9 @@ pub struct CliConfig {
     #[structopt(long)]
     pub verbose: bool,
 
-    /// Process id to launch the daemon on
+    /// Path to PID file.
     #[structopt(long)]
-    pub pid: Option<i32>,
+    pub pid: Option<PathBuf>,
 
     #[structopt(flatten)]
     pub shared_config: SharedConfigValues,
@@ -510,7 +510,13 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
 
     let pid = config
         .pid
-        .and_then(|f| Some(f.to_string()))
+        .and_then(|f| {
+            Some(
+                f.into_os_string()
+                    .into_string()
+                    .expect("Failed to convert PID file path to valid Unicode"),
+            )
+        })
         .or_else(|| None);
 
     let shell = utils::get_shell().unwrap_or_else(|| {


### PR DESCRIPTION
Prior to this commit the pid flag expected an integer as input. This is wrong behaviour. The right data type should be a string pointing to a valid file path.

Closes #340.