### PR TITLE
make ci use cargo lockfile

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           command: build
           toolchain: ${{ matrix.rust }}
-          args: --release --target ${{ matrix.target }} --no-default-features --features "${{ matrix.feature }},${{ matrix.audio_backend }}_backend"
+          args: --locked --release --target ${{ matrix.target }} --no-default-features --features "${{ matrix.feature }},${{ matrix.audio_backend }}_backend"
       
       - name: Packaging final binary
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,4 +78,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --no-default-features --features ${{ matrix.features }}
+          args: --locked --no-default-features --features ${{ matrix.features }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
 - RUSTFLAGS="" cargo clippy --all-features --all-targets -- -D warnings
 - cargo fmt -- --check
 - rustup target add $TARGET
-- cargo build --target=$TARGET --release
+- cargo build --locked --target=$TARGET --release
 - zip -j spotifyd-`date --iso-8601`-$SHORT_TARGET-slim.zip target/$TARGET/release/spotifyd
 - if [ $SHORT_TARGET = "x86" ]; then cargo build --target=$TARGET --release --features "pulseaudio_backend"; fi
 - if [ $SHORT_TARGET = "x86" ]; then zip -j spotifyd-`date --iso-8601`-$SHORT_TARGET-pulseaudio.zip target/$TARGET/release/spotifyd; fi


### PR DESCRIPTION
Prior to this commit, the CI builds didn't use the Cargo.lock file to build binaries. This commit will make CI builds fail if the lockfile didn't get updated after a version bump.

Closes #320.