### PR TITLE
Added option to use credential-only caching as described in #351

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -437,7 +437,7 @@ impl SharedConfigValues {
         // Handles boolean merging.
         self.use_keyring |= other.use_keyring;
         self.volume_normalisation |= other.volume_normalisation;
-        self.no_audio_cache |= !(other.no_audio_cache);
+        self.no_audio_cache |= other.no_audio_cache;
     }
 }
 
@@ -483,7 +483,7 @@ pub(crate) struct SpotifydConfig {
 }
 
 pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
-    let no_audio_cache = config.shared_config.no_audio_cache;
+    let no_audio_cache = !config.shared_config.no_audio_cache;
 
     let cache = config
         .shared_config

--- a/src/config.rs
+++ b/src/config.rs
@@ -235,10 +235,10 @@ pub struct SharedConfigValues {
     #[structopt(long, parse(from_os_str), short, value_name = "string")]
     cache_path: Option<PathBuf>,
 
-    /// Enable to use audio cache
+    /// Disable the use of audio cache
     #[structopt(long)]
     #[serde(default, deserialize_with = "de_from_str")]
-    audio_cache: bool,
+    no_audio_cache: bool,
 
     /// The audio backend to use
     #[structopt(long, short, possible_values = &BACKEND_VALUES, value_name = "string")]
@@ -346,7 +346,7 @@ impl fmt::Debug for SharedConfigValues {
             .field("use_keyring", &self.use_keyring)
             .field("on_song_change_hook", &self.on_song_change_hook)
             .field("cache_path", &self.cache_path)
-            .field("audio_cache", &self.audio_cache)
+            .field("no-audio-cache", &self.no_audio_cache)
             .field("backend", &self.backend)
             .field("volume_controller", &self.volume_controller)
             .field("device", &self.device)
@@ -437,7 +437,7 @@ impl SharedConfigValues {
         // Handles boolean merging.
         self.use_keyring |= other.use_keyring;
         self.volume_normalisation |= other.volume_normalisation;
-        self.audio_cache |= other.audio_cache;
+        self.no_audio_cache |= !(other.no_audio_cache);
     }
 }
 
@@ -465,8 +465,6 @@ pub(crate) struct SpotifydConfig {
     #[allow(unused)]
     pub(crate) use_keyring: bool,
     pub(crate) cache: Option<Cache>,
-    #[allow(unused)]
-    pub(crate) audio_cache: bool,
     pub(crate) backend: Option<String>,
     pub(crate) audio_device: Option<String>,
     #[allow(unused)]
@@ -485,13 +483,13 @@ pub(crate) struct SpotifydConfig {
 }
 
 pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
-    let audio_cache = config.shared_config.audio_cache;
+    let no_audio_cache = config.shared_config.no_audio_cache;
 
     let cache = config
         .shared_config
         .cache_path
         .map(PathBuf::from)
-        .and_then(|path| Some(Cache::new(path, audio_cache)));
+        .and_then(|path| Some(Cache::new(path, no_audio_cache)));
 
     let bitrate: LSBitrate = config
         .shared_config
@@ -553,7 +551,6 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         password,
         use_keyring: config.shared_config.use_keyring,
         cache,
-        audio_cache,
         backend: Some(backend),
         audio_device: config.shared_config.device,
         control_device: config.shared_config.control,

--- a/src/config.rs
+++ b/src/config.rs
@@ -483,13 +483,13 @@ pub(crate) struct SpotifydConfig {
 }
 
 pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
-    let no_audio_cache = !config.shared_config.no_audio_cache;
+    let audio_cache = !config.shared_config.no_audio_cache;
 
     let cache = config
         .shared_config
         .cache_path
         .map(PathBuf::from)
-        .and_then(|path| Some(Cache::new(path, no_audio_cache)));
+        .and_then(|path| Some(Cache::new(path, audio_cache)));
 
     let bitrate: LSBitrate = config
         .shared_config


### PR DESCRIPTION
Added option to use credential-only caching as described in issue #351 

By default this uses credential-only caching which might be not the best approach, as the default value was hardcoded with "true".

Let me know if you want to change this.


Disclaimer: I'm pretty new to all of this, so just tell me if I did something stupid. 

Edit: Fix #351 