### PR TITLE
Added option to enable debugging in the login process

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -324,9 +324,9 @@ impl FileConfig {
 fn sanitize_user_cred(debug_login: bool, input_value: &Option<String>) -> Option<&str> {
     if input_value.is_some() {
         if debug_login {
-            input_value.as_ref().map(|x| &**x).unwrap();
+            return Some(input_value.as_ref().map(|x| &**x).unwrap());
         } else {
-            "taken out for privacy";
+            return Some("taken out for privacy");
         }
     }
     None


### PR DESCRIPTION
This might be a potential fix for #355

I added the option called _debug-login_ (you might want to rename this) which shows the given username, password and password command.

Rewrote some of the code and used a new function for this.

(This is a new pull request because I fucked up some things on the other one... it's possible that this will happen here as well... I'm sorry for that!)

Edit: After I fucked up again, you might need to tell me how to do it properly because at this point it's getting embarrassing...