### PR TITLE
only allow non-whitespace/non-empty names

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -511,8 +511,9 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
     let device_name = config
         .shared_config
         .device_name
+        .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| format!("{}@{}", "Spotifyd", gethostname().to_string_lossy()));
-
+    
     let device_id = device_id(&device_name);
 
     let normalisation_pregain = config.shared_config.normalisation_pregain.unwrap_or(0.0f32);

--- a/src/config.rs
+++ b/src/config.rs
@@ -513,7 +513,7 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         .device_name
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| format!("{}@{}", "Spotifyd", gethostname().to_string_lossy()));
-    
+
     let device_id = device_id(&device_name);
 
     let normalisation_pregain = config.shared_config.normalisation_pregain.unwrap_or(0.0f32);


### PR DESCRIPTION
`device_name=""` (on purpose/by accident) will is set to default `Spotifyd@$HOSTNAME`. 

Fixes #378 

not sure what rustfmt can complain about with this little change...