### PR TITLE
replace device name with default if contains whitespace

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -511,8 +511,9 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
     let device_name = config
         .shared_config
         .device_name
+        .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| format!("{}@{}", "Spotifyd", gethostname().to_string_lossy()));
-
+    
     let device_id = device_id(&device_name);
 
     let normalisation_pregain = config.shared_config.normalisation_pregain.unwrap_or(0.0f32);

--- a/src/config.rs
+++ b/src/config.rs
@@ -512,7 +512,6 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         .shared_config
         .device_name
         .filter(|s| !s.trim().is_empty())
-        .filter(|s| !utils::contains_whitespace(&s))
         .unwrap_or_else(|| format!("{}@{}", "Spotifyd", gethostname().to_string_lossy()));
 
     let device_id = device_id(&device_name);

--- a/src/config.rs
+++ b/src/config.rs
@@ -512,6 +512,7 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         .shared_config
         .device_name
         .filter(|s| !s.trim().is_empty())
+        .filter(|s| !s.chars().any(char::is_whitespace))
         .unwrap_or_else(|| format!("{}@{}", "Spotifyd", gethostname().to_string_lossy()));
 
     let device_id = device_id(&device_name);

--- a/src/config.rs
+++ b/src/config.rs
@@ -513,7 +513,7 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         .device_name
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| format!("{}@{}", "Spotifyd", gethostname().to_string_lossy()));
-    
+
     let device_id = device_id(&device_name);
 
     let normalisation_pregain = config.shared_config.normalisation_pregain.unwrap_or(0.0f32);

--- a/src/config.rs
+++ b/src/config.rs
@@ -512,6 +512,7 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         .shared_config
         .device_name
         .filter(|s| !s.trim().is_empty())
+        .filter(|s| !utils::contains_whitespace(&s))
         .unwrap_or_else(|| format!("{}@{}", "Spotifyd", gethostname().to_string_lossy()));
 
     let device_id = device_id(&device_name);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,13 +1,13 @@
 use whoami;
 
-use log;
+use log::{warn, trace};
 use std::env;
 
 pub(crate) fn get_shell() -> Option<String> {
     // First look for the user's preferred shell using the SHELL environment
     // variable...
     if let Ok(shell) = env::var("SHELL") {
-        log::trace!("Found shell {:?} using SHELL environment variable.", shell);
+        trace!("Found shell {:?} using SHELL environment variable.", shell);
         return Some(shell);
     }
 
@@ -32,7 +32,7 @@ pub(crate) fn get_shell() -> Option<String> {
             if let Some(user) = iter.nth(0) {
                 if user == username {
                     let shell = iter.nth(5)?;
-                    log::trace!("Found shell {:?} using /etc/passwd.", shell);
+                    trace!("Found shell {:?} using /etc/passwd.", shell);
                     return Some(shell.into());
                 }
             }
@@ -57,7 +57,7 @@ pub(crate) fn get_shell() -> Option<String> {
             // "UserShell: /path/to/shell"
             if stdout.starts_with("UserShell: ") {
                 let shell = stdout.split_whitespace().nth(1)?;
-                log::trace!("Found shell {:?} using dscl command.", shell);
+                trace!("Found shell {:?} using dscl command.", shell);
                 return Some(shell.to_string());
             }
         }
@@ -68,7 +68,7 @@ pub(crate) fn get_shell() -> Option<String> {
 pub fn contains_whitespace(s: &str) -> bool {
     let found_space = s.find(|c: char| c.is_whitespace()) != None;
     if found_space {
-        log::warn!("device name contains whitespace. Set to default!");
+        warn!("device name contains whitespace. Set to default!");
     }
 
     found_space

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,13 +1,12 @@
 use whoami;
 
-use log::{warn, trace};
 use std::env;
 
 pub(crate) fn get_shell() -> Option<String> {
     // First look for the user's preferred shell using the SHELL environment
     // variable...
     if let Ok(shell) = env::var("SHELL") {
-        trace!("Found shell {:?} using SHELL environment variable.", shell);
+        log::trace!("Found shell {:?} using SHELL environment variable.", shell);
         return Some(shell);
     }
 
@@ -32,7 +31,7 @@ pub(crate) fn get_shell() -> Option<String> {
             if let Some(user) = iter.nth(0) {
                 if user == username {
                     let shell = iter.nth(5)?;
-                    trace!("Found shell {:?} using /etc/passwd.", shell);
+                    log::trace!("Found shell {:?} using /etc/passwd.", shell);
                     return Some(shell.into());
                 }
             }
@@ -57,7 +56,7 @@ pub(crate) fn get_shell() -> Option<String> {
             // "UserShell: /path/to/shell"
             if stdout.starts_with("UserShell: ") {
                 let shell = stdout.split_whitespace().nth(1)?;
-                trace!("Found shell {:?} using dscl command.", shell);
+                log::trace!("Found shell {:?} using dscl command.", shell);
                 return Some(shell.to_string());
             }
         }
@@ -65,21 +64,12 @@ pub(crate) fn get_shell() -> Option<String> {
     None
 }
 
-pub fn contains_whitespace(s: &str) -> bool {
-    let found_space = s.find(|c: char| c.is_whitespace()) != None;
-    if found_space {
-        warn!("device name contains whitespace. Set to default!");
-    }
-
-    found_space
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_get_shell() {
+    fn it_works() {
         env::set_var("RUST_LOG", "spotifyd=trace");
 
         env_logger::init();
@@ -90,12 +80,5 @@ mod tests {
             env::remove_var("SHELL");
             let _ = get_shell().unwrap();
         }
-    }
-
-    #[test]
-    fn test_contains_whitespace() {
-        assert!(contains_whitespace("hi there"));
-        assert!(contains_whitespace(" hi there "));
-        assert!(!contains_whitespace("hithere"));
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use whoami;
 
+use log;
 use std::env;
 
 pub(crate) fn get_shell() -> Option<String> {
@@ -64,12 +65,21 @@ pub(crate) fn get_shell() -> Option<String> {
     None
 }
 
+pub fn contains_whitespace(s: &str) -> bool {
+    let found_space = s.find(|c: char| c.is_whitespace()) != None;
+    if found_space {
+        log::warn!("device name contains whitespace. Set to default!");
+    }
+
+    found_space
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
+    fn test_get_shell() {
         env::set_var("RUST_LOG", "spotifyd=trace");
 
         env_logger::init();
@@ -80,5 +90,12 @@ mod tests {
             env::remove_var("SHELL");
             let _ = get_shell().unwrap();
         }
+    }
+
+    #[test]
+    fn test_contains_whitespace() {
+        assert!(contains_whitespace("hi there"));
+        assert!(contains_whitespace(" hi there "));
+        assert!(!contains_whitespace("hithere"));
     }
 }


### PR DESCRIPTION
I'm not sure, why the device name can't contain whitespaces. However, I would just replace/ignore device names entered with whitespaces with the default, and warn the user. Which is what this does. Consider this PR highly opinionated and optional :D 

Closes #378.