### PR TITLE
refactor(utils): refactor get_shell to use native function calls on Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ tokio-core = "0.1"
 tokio-io = "0.1"
 tokio-signal = "0.1"
 xdg = "2.2"
+
+[target.'cfg(macos)'.dependencies]
 whoami = "0.5.3"
 
 [dependencies.librespot]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,6 +11,7 @@ pub(crate) fn get_shell() -> Option<String> {
 
 #[cfg(target_os = "macos")]
 fn get_shell_ffi() -> Option<String> {
+    use whoami;
     use std::process::Command;
 
     let username = whoami::username();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,7 @@ use log::trace;
 use std::env;
 
 pub(crate) fn get_shell() -> Option<String> {
-    let shell = env::var("SHELL").ok().or_else(|| get_shell_ffi());
+    let shell = env::var("SHELL").ok().or_else(get_shell_ffi);
     trace!("Found user shell: {:?}", &shell);
 
     shell

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,8 +11,8 @@ pub(crate) fn get_shell() -> Option<String> {
 
 #[cfg(target_os = "macos")]
 fn get_shell_ffi() -> Option<String> {
-    use whoami;
     use std::process::Command;
+    use whoami;
 
     let username = whoami::username();
     let output = Command::new("dscl")


### PR DESCRIPTION
This commit uses the libc crate to retrieve the users shell instead of relying on parsing the /etc/passwd file