### PR TITLE
README: clearify the space after equal sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ The configuration file has the following format:
 
 ```ini
 [global]
-# Your Spotify account name.
-username = username
+# Your Spotify account name (no space after = sign).
+username =username
 
-# Your Spotify account password.
-password = password
+# Your Spotify account password(no space after = sign).
+password =password
 
 # A command that gets executed and can be used to
 # retrieve your password.


### PR DESCRIPTION
i spent 3 hours woundering what is wrong until i went throw all issues and found this only mentioned in ome of them
something like this should be cleared here in readme