### PR TITLE
chore(templates): add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Description**
+<!-- A clear and concise description of what the bug is -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen (if applicable) -->
+
+**Logs**
+<details><summary>Click to show logs</summary>
+<!-- Please paste your logs below when reporting bugs. Make sure to run spotifyd using the `--verbose` flag  -->
+</details>
+
+<!-- if you compiled spotifyd yourself. Alsa backend enabled by default unless compiled with the `--no-default-features` flag -->
+**Compilation flags** 
+- [ ] dbus_mpris
+- [ ] dbus_keyring
+- [x] alsa_backend
+- [ ] portaudio_backend
+- [ ] pulseaudio_backend
+- [ ] rodio_backend
+
+**Versions (please complete the following information):**
+ - OS: <!-- e.g. Ubuntu 18.04 LTS, Windows 10 -->
+ - Spotifyd: <!-- branch, commit hash or release version -->
+
+<!-- **Additional context**
+Add any other context about the problem here. -->


### PR DESCRIPTION
This PR adds an issue template to the repo. The template mentions information that can be used to reproduce the bug and actively mentions the logs that should always be attached to issues.