### PR TITLE
refactor: report name of selem that cannot be found

### DIFF
--- a/src/alsa_mixer.rs
+++ b/src/alsa_mixer.rs
@@ -15,7 +15,7 @@ impl AlsaMixer {
         let mixer = alsa::mixer::Mixer::new(&self.device, false)?;
 
         let selem_id = alsa::mixer::SelemId::new(&*self.mixer, 0);
-        let elem = mixer.find_selem(&selem_id).ok_or(format!(
+        let elem = mixer.find_selem(&selem_id).ok_or_else(|| format!(
             "Couldn't find selem with name '{}'.",
             selem_id.get_name().unwrap_or("unnamed")
         ))?;

--- a/src/alsa_mixer.rs
+++ b/src/alsa_mixer.rs
@@ -15,7 +15,7 @@ impl AlsaMixer {
         let mixer = alsa::mixer::Mixer::new(&self.device, false)?;
 
         let selem_id = alsa::mixer::SelemId::new(&*self.mixer, 0);
-        let elem = mixer.find_selem(&selem_id).ok_or("Couldn't find selem.")?;
+        let elem = mixer.find_selem(&selem_id).ok_or(format!("Couldn't find selem with name '{}'.", selem_id.get_name().unwrap_or("unnamed")))?;
 
         let (min, max) = elem.get_playback_volume_range();
 

--- a/src/alsa_mixer.rs
+++ b/src/alsa_mixer.rs
@@ -15,7 +15,10 @@ impl AlsaMixer {
         let mixer = alsa::mixer::Mixer::new(&self.device, false)?;
 
         let selem_id = alsa::mixer::SelemId::new(&*self.mixer, 0);
-        let elem = mixer.find_selem(&selem_id).ok_or(format!("Couldn't find selem with name '{}'.", selem_id.get_name().unwrap_or("unnamed")))?;
+        let elem = mixer.find_selem(&selem_id).ok_or(format!(
+            "Couldn't find selem with name '{}'.",
+            selem_id.get_name().unwrap_or("unnamed")
+        ))?;
 
         let (min, max) = elem.get_playback_volume_range();
 

--- a/src/alsa_mixer.rs
+++ b/src/alsa_mixer.rs
@@ -15,10 +15,12 @@ impl AlsaMixer {
         let mixer = alsa::mixer::Mixer::new(&self.device, false)?;
 
         let selem_id = alsa::mixer::SelemId::new(&*self.mixer, 0);
-        let elem = mixer.find_selem(&selem_id).ok_or_else(|| format!(
-            "Couldn't find selem with name '{}'.",
-            selem_id.get_name().unwrap_or("unnamed")
-        ))?;
+        let elem = mixer.find_selem(&selem_id).ok_or_else(|| {
+            format!(
+                "Couldn't find selem with name '{}'.",
+                selem_id.get_name().unwrap_or("unnamed")
+            )
+        })?;
 
         let (min, max) = elem.get_playback_volume_range();
 


### PR DESCRIPTION
If a user's volume control is not correctly configured the following (unhelpful) warning is logged:

> Couldn't set volume: "Couldn\'t find selem."

It does not say _which_ selem cannot be found. Let's output this information to help users debug their configuration files.

In my case this PR helped me discover that it was using `PCM` as the name of the selem instead of `alsa`. This led me to #283 which solved my problem.