### PR TITLE
fix option_and_then_some lint error

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -495,7 +495,7 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         .shared_config
         .cache_path
         .map(PathBuf::from)
-        .and_then(|path| Some(Cache::new(path, audio_cache)));
+        .map(|path| Cache::new(path, audio_cache));
 
     let bitrate: LSBitrate = config
         .shared_config
@@ -527,12 +527,10 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
 
     let pid = config
         .pid
-        .and_then(|f| {
-            Some(
-                f.into_os_string()
-                    .into_string()
-                    .expect("Failed to convert PID file path to valid Unicode"),
-            )
+        .map(|f| {
+            f.into_os_string()
+                .into_string()
+                .expect("Failed to convert PID file path to valid Unicode")
         })
         .or_else(|| None);
 


### PR DESCRIPTION
The latest version of clippy includes the [option_and_then_some](https://rust-lang.github.io/rust-clippy/master/index.html#option_and_then_some) check which is causing recent builds to fail.

Example failing build: https://github.com/Spotifyd/spotifyd/pull/437/checks?check_run_id=319826888#step:6:566