### PR TITLE
fix(mpris): position property now returns value in microseconds

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -495,7 +495,7 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         .shared_config
         .cache_path
         .map(PathBuf::from)
-        .map(|path| Cache::new(path, audio_cache));
+        .and_then(|path| Some(Cache::new(path, audio_cache)));
 
     let bitrate: LSBitrate = config
         .shared_config
@@ -527,10 +527,12 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
 
     let pid = config
         .pid
-        .map(|f| {
-            f.into_os_string()
-                .into_string()
-                .expect("Failed to convert PID file path to valid Unicode")
+        .and_then(|f| {
+            Some(
+                f.into_os_string()
+                    .into_string()
+                    .expect("Failed to convert PID file path to valid Unicode"),
+            )
         })
         .or_else(|| None);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -495,7 +495,7 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         .shared_config
         .cache_path
         .map(PathBuf::from)
-        .and_then(|path| Some(Cache::new(path, audio_cache)));
+        .map(|path| Cache::new(path, audio_cache));
 
     let bitrate: LSBitrate = config
         .shared_config
@@ -527,12 +527,10 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
 
     let pid = config
         .pid
-        .and_then(|f| {
-            Some(
-                f.into_os_string()
-                    .into_string()
-                    .expect("Failed to convert PID file path to valid Unicode"),
-            )
+        .map(|f| {
+            f.into_os_string()
+                .into_string()
+                .expect("Failed to convert PID file path to valid Unicode")
         })
         .or_else(|| None);
 

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -417,7 +417,7 @@ fn create_dbus_server(
             if let Ok(Some(pos)) =
                 sp.current_playback(None)
                 .map(|maybe_player| maybe_player.and_then(|p| p.progress_ms)) {
-                i64::from(pos)
+                i64::from(pos) * 1000
             } else {
                 0
             }


### PR DESCRIPTION
Position should be returned in microseconds.
See https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Position