### PR TITLE
Add proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,6 +2554,7 @@ dependencies = [
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "whoami 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ syslog = "4.0.1"
 tokio-core = "0.1"
 tokio-io = "0.1"
 tokio-signal = "0.1"
+url = "1.7"
 xdg = "2.2"
 whoami = "0.6.0"
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ normalisation_pregain = -10
 
 # The port `spotifyd` uses to announce its service over the network.
 zeroconf_port = 1234
+
+# The proxy `spotifyd` will use to connect to spotify.
+proxy = http://proxy.example.org:8080
 ```
 
 #### Alternatives to storing your password in the config file <!-- omit in toc -->

--- a/src/config.rs
+++ b/src/config.rs
@@ -493,7 +493,6 @@ pub(crate) struct SpotifydConfig {
     pub(crate) pid: Option<String>,
     pub(crate) shell: String,
     pub(crate) zeroconf_port: Option<u16>,
-//   pub(crate) proxy: Option<url::Url>,
 }
 
 pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use serde::{de, Deserialize};
 use sha1::{Digest, Sha1};
 use structopt::{clap::AppSettings, StructOpt};
 use xdg;
+use url::{Url};
 
 use std::{fmt, fs, io::BufRead, path::PathBuf, str::FromStr, string::ToString};
 
@@ -287,6 +288,10 @@ pub struct SharedConfigValues {
     /// The port used for the Spotify Connect discovery
     #[structopt(long, value_name = "number")]
     zeroconf_port: Option<u16>,
+
+    /// The proxy used to connect to spotify's servers
+    #[structopt(long, short, value_name="string")]
+    proxy: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -363,6 +368,7 @@ impl fmt::Debug for SharedConfigValues {
             .field("volume_normalisation", &self.volume_normalisation)
             .field("normalisation_pregain", &self.normalisation_pregain)
             .field("zeroconf_port", &self.zeroconf_port)
+            .field("proxy", &self.proxy)
             .finish()
     }
 }
@@ -437,7 +443,8 @@ impl SharedConfigValues {
             device,
             volume_controller,
             cache_path,
-            on_song_change_hook
+            on_song_change_hook,
+            proxy
         );
 
         // Handles boolean merging.
@@ -486,6 +493,7 @@ pub(crate) struct SpotifydConfig {
     pub(crate) pid: Option<String>,
     pub(crate) shell: String,
     pub(crate) zeroconf_port: Option<u16>,
+//   pub(crate) proxy: Option<url::Url>,
 }
 
 pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
@@ -551,7 +559,23 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
             None => info!("No password_cmd specified"),
         }
     }
-
+    let proxy_url = config.shared_config.proxy.or(None).map(
+                |s| {
+                    match Url::parse(&s) {
+                        Ok(url) => {
+                            if url.scheme() != "http" {
+                                error!("Only HTTP proxies are supported!");
+                                return None;
+                            }
+                            Some(url)
+                        },
+                        Err(err) => {
+                            error!("Invalid proxy URL: {}", err);
+                            None
+                        }
+                    }
+                },
+            ).unwrap();
     SpotifydConfig {
         username: config.shared_config.username,
         password,
@@ -571,7 +595,7 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         session_config: SessionConfig {
             user_agent: version::version_string(),
             device_id,
-            proxy: None,
+            proxy: proxy_url,
             ap_port: Some(443),
         },
         onevent: config.shared_config.on_song_change_hook,

--- a/src/config.rs
+++ b/src/config.rs
@@ -558,23 +558,22 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
             None => info!("No password_cmd specified"),
         }
     }
-    let proxy_url = config.shared_config.proxy.or(None).map(
-                |s| {
-                    match Url::parse(&s) {
-                        Ok(url) => {
-                            if url.scheme() != "http" {
-                                error!("Only HTTP proxies are supported!");
-                                return None;
-                            }
-                            Some(url)
-                        },
-                        Err(err) => {
-                            error!("Invalid proxy URL: {}", err);
-                            None
-                        }
+    let mut proxy_url = None;
+    match config.shared_config.proxy{
+        Some(s) => {
+            match Url::parse(&s) {
+                Ok(url) => {
+                    if url.scheme() != "http" {
+                        error!("Only HTTP proxies are supported!");
+                    } else {
+                        proxy_url = Some(url);
                     }
                 },
-            ).unwrap();
+                Err(err) => error!("Invalid proxy URL: {}", err)
+            }
+        },
+        None => info!("No proxy specified"),
+    }
     SpotifydConfig {
         username: config.shared_config.username,
         password,


### PR DESCRIPTION
Librespot supports using HTTP proxies to connect to spotify servers. This PR adds a config directive for that. 

This might also help some people who experience an error like in #175  . Helped me at least.

Fixes #143.