### PR TITLE
revert path filter for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,5 @@ deploy:
   file_glob: true
   file: "spotifyd*zip"
   skip_cleanup: true
-  on: [push, pull_request]
-    paths: '**.rs'
     branch: master
     tags: true


### PR DESCRIPTION
Travis doesn't support filtering for file paths or types of commit.