### PR TITLE
Improve CD workflow matrix (fixes #464)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,18 +7,18 @@ on:
 
 jobs:
   publish:
-    name: Publishing for ${{ matrix.os }}
+    name: Publishing ${{ matrix.build_target }}-${{ matrix.artifact_type }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build_target: [macos, macos-rodio, ubuntu]
+        build_target: [macos, macos-rodio, linux]
         rust: [stable]
-        feature: [
-          '',                                             # Slim version has no features enabled by default.
-          'dbus_keyring,dbus_mpris'                       # Full version has all OS compatible features enabled
-        ]
-        artifact_type: ['slim', 'full']                   # The build strategy will build both types for each OS specified
+        artifact_type: ['slim', 'full']         # The build strategy will build both types for each OS specified
         include:
+          - artifact_type: 'slim'               # Slim version has no features enabled by default.
+            feature: ''
+          - artifact_type: 'full'
+            feature: 'dbus_keyring,dbus_mpris'  # Full version has all OS compatible features enabled
           - build_target: macos
             os: macos-latest
             artifact_prefix: macos
@@ -29,7 +29,7 @@ jobs:
             artifact_prefix: macos-rodio
             audio_backend: rodio
             target: x86_64-apple-darwin
-          - build_target: ubuntu
+          - build_target: linux
             os: ubuntu-latest
             artifact_prefix: linux
             audio_backend: alsa


### PR DESCRIPTION
This project uses GitHub Actions to create builds, which is great. However, the workflow for this uses a build matrix that builds every `artifact_type` (slim, full) for every `build_target` (macos, macos-rodio, ubuntu) for every `feature` ('', 'dbus_keyring,dbus_mpris).

So the `cd.yml` creates twice as many workers than necessary, while occasionally overwriting the "slim" version with a "slim" version that has all features enabled (and the other way round), see #464.

This PR improves three things:

* Rename the "ubuntu" target to "linux", so it better represents what it does
* Set the name of the job to "macos-slim", "macos-full", "linux-slim", etc. to give a better overview which jobs are running
* Move the feature definition into the `include` node, this solves a multiplication of workers creating the wrong artifacts

I'll try to adapt the workflow for armhf cross compilation, however this is somewhat complicated because of the system dependencies (alsa, dbus).