### PR TITLE
add CD support for armv6 and armv7

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,36 +56,36 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y -qq libasound2-dev libssl-dev libpulse-dev libdbus-1-dev
       - name: Installing needed Ubuntu armhf dependencies (slim)
-        if: matrix.os == 'ubuntu-18.04' && matrix.target == 'arm-unknown-linux-gnueabihf'
+        if: matrix.os == 'ubuntu-18.04' && matrix.build_target == 'linux-armhf'
         run: |
-          sudo mkdir -p /build/deps_root
+          sudo mkdir -p /build/sysroot
           echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ bionic main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get install -y -qq gcc-arm-linux-gnueabihf libc6-armhf-cross libc6-dev-armhf-cross
           sudo apt-get download libasound2:armhf libasound2-dev:armhf libssl-dev:armhf libssl1.1:armhf
-          sudo dpkg -x libasound2_*.deb /build/deps_root/
-          sudo dpkg -x libssl-dev*.deb /build/deps_root/
-          sudo dpkg -x libssl1.1*.deb /build/deps_root/
-          sudo dpkg -x libasound2-dev*.deb /build/deps_root/
+          sudo dpkg -x libasound2_*.deb /build/sysroot/
+          sudo dpkg -x libssl-dev*.deb /build/sysroot/
+          sudo dpkg -x libssl1.1*.deb /build/sysroot/
+          sudo dpkg -x libasound2-dev*.deb /build/sysroot/
       - name: Installing needed Ubuntu armhf dependencies (full)
-        if: matrix.os == 'ubuntu-18.04' && matrix.target == 'arm-unknown-linux-gnueabihf' && matrix.artifact_type == 'full'
+        if: matrix.os == 'ubuntu-18.04' && matrix.build_target == 'linux-armhf' && matrix.artifact_type == 'full'
         run: |
           # Make dbus-rs cross-compile, see https://github.com/diwic/dbus-rs/issues/184#issuecomment-520228758
           sudo apt-get download libdbus-1-dev:armhf libdbus-1-3:armhf libsystemd0:armhf libgcrypt20:armhf liblzma5:armhf liblz4-1:armhf libgpg-error0:armhf
-          sudo dpkg -x libdbus-1-3*.deb /build/deps_root/
-          sudo dpkg -x libdbus-1-dev*.deb /build/deps_root/
-          sudo dpkg -x libsystemd0*.deb /build/deps_root/
-          sudo dpkg -x libgcrypt20_*.deb /build/deps_root/
-          sudo dpkg -x liblzma5_*.deb /build/deps_root/
-          sudo dpkg -x liblz4-1_*.deb /build/deps_root/
-          sudo dpkg -x libgpg-error0_*.deb /build/deps_root/
-          sudo rm /build/deps_root/usr/lib/arm-linux-gnueabihf/libdbus-1.so
-          sudo ln -rs /build/deps_root/lib/arm-linux-gnueabihf/libdbus-1.so.3 /build/deps_root/usr/lib/arm-linux-gnueabihf/libdbus-1.so
-          sudo ln -rs /build/deps_root/lib/arm-linux-gnueabihf/libgcrypt.so.20 /build/deps_root/lib/arm-linux-gnueabihf/libgcrypt.so
-          sudo ln -rs /build/deps_root/lib/arm-linux-gnueabihf/libgpg-error.so.0 /build/deps_root/lib/arm-linux-gnueabihf/libgpg-error.so
-          sudo ln -rs /build/deps_root/lib/arm-linux-gnueabihf/liblzma.so.5 /build/deps_root/lib/arm-linux-gnueabihf/liblzma.so
-          sudo ln -rs /build/deps_root/lib/arm-linux-gnueabihf/libsystemd.so.0 /build/deps_root/lib/arm-linux-gnueabihf/libsystemd.so
-          sudo ln -rs /build/deps_root/usr/lib/arm-linux-gnueabihf/liblz4.so.1 /build/deps_root/usr/lib/arm-linux-gnueabihf/liblz4.so
+          sudo dpkg -x libdbus-1-3*.deb /build/sysroot/
+          sudo dpkg -x libdbus-1-dev*.deb /build/sysroot/
+          sudo dpkg -x libsystemd0*.deb /build/sysroot/
+          sudo dpkg -x libgcrypt20_*.deb /build/sysroot/
+          sudo dpkg -x liblzma5_*.deb /build/sysroot/
+          sudo dpkg -x liblz4-1_*.deb /build/sysroot/
+          sudo dpkg -x libgpg-error0_*.deb /build/sysroot/
+          sudo rm /build/sysroot/usr/lib/arm-linux-gnueabihf/libdbus-1.so
+          sudo ln -rs /build/sysroot/lib/arm-linux-gnueabihf/libdbus-1.so.3 /build/sysroot/usr/lib/arm-linux-gnueabihf/libdbus-1.so
+          sudo ln -rs /build/sysroot/lib/arm-linux-gnueabihf/libgcrypt.so.20 /build/sysroot/lib/arm-linux-gnueabihf/libgcrypt.so
+          sudo ln -rs /build/sysroot/lib/arm-linux-gnueabihf/libgpg-error.so.0 /build/sysroot/lib/arm-linux-gnueabihf/libgpg-error.so
+          sudo ln -rs /build/sysroot/lib/arm-linux-gnueabihf/liblzma.so.5 /build/sysroot/lib/arm-linux-gnueabihf/liblzma.so
+          sudo ln -rs /build/sysroot/lib/arm-linux-gnueabihf/libsystemd.so.0 /build/sysroot/lib/arm-linux-gnueabihf/libsystemd.so
+          sudo ln -rs /build/sysroot/usr/lib/arm-linux-gnueabihf/liblz4.so.1 /build/sysroot/usr/lib/arm-linux-gnueabihf/liblz4.so
           mkdir -p .cargo
           echo -e '[target.arm-unknown-linux-gnueabihf.dbus]\nrustc-link-lib = ["dbus-1", "gcrypt", "gpg-error", "lz4", "lzma", "systemd"]' >> .cargo/config
       - name: Checking out sources
@@ -105,10 +105,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
           args: --locked --release --target ${{ matrix.target }} --no-default-features --features "${{ matrix.feature }},${{ matrix.audio_backend }}_backend"
         env:
-          RUSTFLAGS: "-C linker=arm-linux-gnueabihf-gcc -L/usr/arm-linux-gnueabihf/lib -L/build/deps_root/usr/lib/arm-linux-gnueabihf -L/build/deps_root/lib/arm-linux-gnueabihf"
+          RUSTFLAGS: "-C linker=arm-linux-gnueabihf-gcc -L/usr/arm-linux-gnueabihf/lib -L/build/sysroot/usr/lib/arm-linux-gnueabihf -L/build/sysroot/lib/arm-linux-gnueabihf"
           PKG_CONFIG_ALLOW_CROSS: 1
-          OPENSSL_LIB_DIR: /build/deps_root/usr/lib/arm-linux-gnueabihf
-          OPENSSL_INCLUDE_DIR: /build/deps_root/usr/include/arm-linux-gnueabihf
+          OPENSSL_LIB_DIR: /build/sysroot/usr/lib/arm-linux-gnueabihf
+          OPENSSL_INCLUDE_DIR: /build/sysroot/usr/include/arm-linux-gnueabihf
       - name: Packaging final binary
         shell: bash
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,6 +39,11 @@ jobs:
             artifact_prefix: linux-armhf
             audio_backend: alsa
             target: arm-unknown-linux-gnueabihf
+          - build_target: linux-armv6
+            os: ubuntu-18.04
+            artifact_prefix: linux-armv6
+            audio_backend: alsa
+            target: arm-unknown-linux-gnueabihf
         exclude:
           - build_target: linux-armv6
             artifact_type: 'full'               # Raspberry Pi toolchain is too old for dbus/systemd
@@ -58,7 +63,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y -qq libasound2-dev libssl-dev libpulse-dev libdbus-1-dev
-      - name: Installing needed Ubuntu armhf dependencies (slim)
+      - name: Installing needed Ubuntu armhf dependencies
         if: matrix.os == 'ubuntu-18.04' && matrix.build_target == 'linux-armhf'
         run: |
           sudo mkdir -p /build/sysroot
@@ -70,19 +75,30 @@ jobs:
           sudo dpkg -x libssl-dev*.deb /build/sysroot/
           sudo dpkg -x libssl1.1*.deb /build/sysroot/
           sudo dpkg -x libasound2-dev*.deb /build/sysroot/
-      - name: Installing needed Ubuntu armv6 dependencies (slim)
+          echo "::set-env name=PKG_CONFIG_ALLOW_CROSS::1"
+          echo "::set-env name=RUSTFLAGS::-C linker=arm-linux-gnueabihf-gcc -L/usr/arm-linux-gnueabihf/lib -L/build/sysroot/usr/lib/arm-linux-gnueabihf -L/build/sysroot/lib/arm-linux-gnueabihf"
+          echo "::set-env name=C_INCLUDE_PATH::/build/sysroot/usr/include"
+          echo "::set-env name=OPENSSL_LIB_DIR::/build/sysroot/usr/lib/arm-linux-gnueabihf"
+          echo "::set-env name=OPENSSL_INCLUDE_DIR::/build/sysroot/usr/include/arm-linux-gnueabihf"
+      - name: Installing needed Ubuntu armv6 dependencies
         if: matrix.os == 'ubuntu-18.04' && matrix.build_target == 'linux-armv6'
         run: |
           sudo mkdir -p /build/sysroot
           echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ bionic main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get install -y -qq git
-          git -C /build clone --depth=1 https://github.com/raspberrypi/tools.git
+          sudo git -C /build clone --depth=1 https://github.com/raspberrypi/tools.git
           sudo apt-get download libasound2:armhf libasound2-dev:armhf libssl-dev:armhf libssl1.1:armhf
           sudo dpkg -x libasound2_*.deb /build/sysroot/
           sudo dpkg -x libssl-dev*.deb /build/sysroot/
           sudo dpkg -x libssl1.1*.deb /build/sysroot/
           sudo dpkg -x libasound2-dev*.deb /build/sysroot/
+          echo "::add-path::/build/tools/arm-bcm2708/arm-linux-gnueabihf/bin"
+          echo "::set-env name=PKG_CONFIG_ALLOW_CROSS::1"
+          echo "::set-env name=RUSTFLAGS::-C linker=/build/tools/arm-bcm2708/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc -L/build/tools/arm-bcm2708/arm-linux-gnueabihf/arm-linux-gnueabihf/sysroot/lib -L/build/tools/arm-bcm2708/arm-linux-gnueabihf/arm-linux-gnueabihf/sysroot/usr/lib -L/build/sysroot/usr/lib/arm-linux-gnueabihf -L/build/sysroot/lib/arm-linux-gnueabihf"
+          echo "::set-env name=C_INCLUDE_PATH::/build/sysroot/usr/include"
+          echo "::set-env name=OPENSSL_LIB_DIR::/build/sysroot/usr/lib/arm-linux-gnueabihf"
+          echo "::set-env name=OPENSSL_INCLUDE_DIR::/build/sysroot/usr/include/arm-linux-gnueabihf"
       - name: Installing needed Ubuntu armhf dependencies (full)
         if: matrix.os == 'ubuntu-18.04' && matrix.build_target == 'linux-armhf' && matrix.artifact_type == 'full'
         run: |
@@ -95,49 +111,23 @@ jobs:
           sudo dpkg -x liblzma5_*.deb /build/sysroot/
           sudo dpkg -x liblz4-1_*.deb /build/sysroot/
           sudo dpkg -x libgpg-error0_*.deb /build/sysroot/
-          sudo rm /build/sysroot/usr/lib/arm-linux-gnueabihf/libdbus-1.so
-          sudo ln -rs /build/sysroot/lib/arm-linux-gnueabihf/libdbus-1.so.3 /build/sysroot/usr/lib/arm-linux-gnueabihf/libdbus-1.so
+          sudo cp -r /build/sysroot/lib/* /build/sysroot/usr/lib/
+          sudo ln -frs /build/sysroot/lib/arm-linux-gnueabihf/libdbus-1.so.3 /build/sysroot/lib/arm-linux-gnueabihf/libdbus-1.so
           sudo ln -rs /build/sysroot/lib/arm-linux-gnueabihf/libgcrypt.so.20 /build/sysroot/lib/arm-linux-gnueabihf/libgcrypt.so
           sudo ln -rs /build/sysroot/lib/arm-linux-gnueabihf/libgpg-error.so.0 /build/sysroot/lib/arm-linux-gnueabihf/libgpg-error.so
           sudo ln -rs /build/sysroot/lib/arm-linux-gnueabihf/liblzma.so.5 /build/sysroot/lib/arm-linux-gnueabihf/liblzma.so
           sudo ln -rs /build/sysroot/lib/arm-linux-gnueabihf/libsystemd.so.0 /build/sysroot/lib/arm-linux-gnueabihf/libsystemd.so
           sudo ln -rs /build/sysroot/usr/lib/arm-linux-gnueabihf/liblz4.so.1 /build/sysroot/usr/lib/arm-linux-gnueabihf/liblz4.so
-          mkdir -p .cargo
-          echo -e '[target.arm-unknown-linux-gnueabihf.dbus]\nrustc-link-lib = ["dbus-1", "gcrypt", "gpg-error", "lz4", "lzma", "systemd"]' >> .cargo/config
+          sudo mkdir -p /.cargo
+          echo -e '[target.arm-unknown-linux-gnueabihf.dbus]\nrustc-link-lib = ["dbus-1", "gcrypt", "gpg-error", "lz4", "lzma", "systemd"]' | sudo tee -a /.cargo/config
       - name: Checking out sources
         uses: actions/checkout@v1
       - name: Running cargo build
-        if: matrix.target != 'arm-unknown-linux-gnueabihf'
         uses: actions-rs/cargo@v1
         with:
           command: build
           toolchain: ${{ matrix.rust }}
           args: --locked --release --target ${{ matrix.target }} --no-default-features --features "${{ matrix.feature }},${{ matrix.audio_backend }}_backend"
-      - name: Running cargo cross build (armhf)
-        if: matrix.build_target == 'linux-armhf'
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          toolchain: ${{ matrix.rust }}
-          args: --locked --release --target ${{ matrix.target }} --no-default-features --features "${{ matrix.feature }},${{ matrix.audio_backend }}_backend"
-        env:
-          RUSTFLAGS: "-C linker=arm-linux-gnueabihf-gcc -L/usr/arm-linux-gnueabihf/lib -L/build/sysroot/usr/lib/arm-linux-gnueabihf -L/build/sysroot/lib/arm-linux-gnueabihf"
-          PKG_CONFIG_ALLOW_CROSS: 1
-          OPENSSL_LIB_DIR: /build/sysroot/usr/lib/arm-linux-gnueabihf
-          OPENSSL_INCLUDE_DIR: /build/sysroot/usr/include/arm-linux-gnueabihf
-      - name: Running cargo cross build (armv6)
-        if: matrix.build_target == 'linux-armv6'
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          toolchain: ${{ matrix.rust }}
-          args: --locked --release --target ${{ matrix.target }} --no-default-features --features "${{ matrix.feature }},${{ matrix.audio_backend }}_backend"
-        env:
-          PATH: "/build/tools/arm-bcm2708/arm-linux-gnueabihf/bin:$PATH"
-          RUSTFLAGS: "-C linker=/build/tools/arm-bcm2708/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc -L/build/tools/arm-bcm2708/arm-linux-gnueabihf/arm-linux-gnueabihf/sysroot/lib -L/build/tools/arm-bcm2708/arm-linux-gnueabihf/arm-linux-gnueabihf/sysroot/usr/lib -L/build/deps_root/usr/lib/arm-linux-gnueabihf -L/build/deps_root/lib/arm-linux-gnueabihf"
-          PKG_CONFIG_ALLOW_CROSS: 1
-          OPENSSL_LIB_DIR: /build/sysroot/usr/lib/arm-linux-gnueabihf
-          OPENSSL_INCLUDE_DIR: /build/sysroot/usr/include/arm-linux-gnueabihf
       - name: Packaging final binary
         shell: bash
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build_target: [macos, macos-rodio, linux]
+        build_target: [macos, macos-rodio, linux, linux-armhf]
         rust: [stable]
         artifact_type: ['slim', 'full']         # The build strategy will build both types for each OS specified
         include:
@@ -34,40 +34,87 @@ jobs:
             artifact_prefix: linux
             audio_backend: alsa
             target: x86_64-unknown-linux-gnu
+          - build_target: linux-armhf
+            os: ubuntu-18.04
+            artifact_prefix: linux-armhf
+            audio_backend: alsa
+            target: arm-unknown-linux-gnueabihf
 
     steps:
       - name: Installing Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
           override: true
       - name: Installing needed macOS dependencies
         if: matrix.os == 'macos-latest'
         run: brew install awk dbus pkg-config portaudio
       - name: Installing needed Ubuntu dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y -qq libasound2-dev libssl-dev libpulse-dev libdbus-1-dev
-
+      - name: Installing needed Ubuntu armhf dependencies (slim)
+        if: matrix.os == 'ubuntu-18.04' && matrix.target == 'arm-unknown-linux-gnueabihf'
+        run: |
+          sudo mkdir -p /build/deps_root
+          echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ bionic main" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
+          sudo apt-get install -y -qq gcc-arm-linux-gnueabihf libc6-armhf-cross libc6-dev-armhf-cross
+          sudo apt-get download libasound2:armhf libasound2-dev:armhf libssl-dev:armhf libssl1.1:armhf
+          sudo dpkg -x libasound2_*.deb /build/deps_root/
+          sudo dpkg -x libssl-dev*.deb /build/deps_root/
+          sudo dpkg -x libssl1.1*.deb /build/deps_root/
+          sudo dpkg -x libasound2-dev*.deb /build/deps_root/
+      - name: Installing needed Ubuntu armhf dependencies (full)
+        if: matrix.os == 'ubuntu-18.04' && matrix.target == 'arm-unknown-linux-gnueabihf' && matrix.artifact_type == 'full'
+        run: |
+          # Make dbus-rs cross-compile, see https://github.com/diwic/dbus-rs/issues/184#issuecomment-520228758
+          sudo apt-get download libdbus-1-dev:armhf libdbus-1-3:armhf libsystemd0:armhf libgcrypt20:armhf liblzma5:armhf liblz4-1:armhf libgpg-error0:armhf
+          sudo dpkg -x libdbus-1-3*.deb /build/deps_root/
+          sudo dpkg -x libdbus-1-dev*.deb /build/deps_root/
+          sudo dpkg -x libsystemd0*.deb /build/deps_root/
+          sudo dpkg -x libgcrypt20_*.deb /build/deps_root/
+          sudo dpkg -x liblzma5_*.deb /build/deps_root/
+          sudo dpkg -x liblz4-1_*.deb /build/deps_root/
+          sudo dpkg -x libgpg-error0_*.deb /build/deps_root/
+          sudo rm /build/deps_root/usr/lib/arm-linux-gnueabihf/libdbus-1.so
+          sudo ln -rs /build/deps_root/lib/arm-linux-gnueabihf/libdbus-1.so.3 /build/deps_root/usr/lib/arm-linux-gnueabihf/libdbus-1.so
+          sudo ln -rs /build/deps_root/lib/arm-linux-gnueabihf/libgcrypt.so.20 /build/deps_root/lib/arm-linux-gnueabihf/libgcrypt.so
+          sudo ln -rs /build/deps_root/lib/arm-linux-gnueabihf/libgpg-error.so.0 /build/deps_root/lib/arm-linux-gnueabihf/libgpg-error.so
+          sudo ln -rs /build/deps_root/lib/arm-linux-gnueabihf/liblzma.so.5 /build/deps_root/lib/arm-linux-gnueabihf/liblzma.so
+          sudo ln -rs /build/deps_root/lib/arm-linux-gnueabihf/libsystemd.so.0 /build/deps_root/lib/arm-linux-gnueabihf/libsystemd.so
+          sudo ln -rs /build/deps_root/usr/lib/arm-linux-gnueabihf/liblz4.so.1 /build/deps_root/usr/lib/arm-linux-gnueabihf/liblz4.so
+          mkdir -p .cargo
+          echo -e '[target.arm-unknown-linux-gnueabihf.dbus]\nrustc-link-lib = ["dbus-1", "gcrypt", "gpg-error", "lz4", "lzma", "systemd"]' >> .cargo/config
       - name: Checking out sources
         uses: actions/checkout@v1
       - name: Running cargo build
+        if: matrix.target != 'arm-unknown-linux-gnueabihf'
         uses: actions-rs/cargo@v1
         with:
           command: build
           toolchain: ${{ matrix.rust }}
           args: --locked --release --target ${{ matrix.target }} --no-default-features --features "${{ matrix.feature }},${{ matrix.audio_backend }}_backend"
-      
+      - name: Running cargo cross build
+        if: matrix.target == 'arm-unknown-linux-gnueabihf'
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          toolchain: ${{ matrix.rust }}
+          args: --locked --release --target ${{ matrix.target }} --no-default-features --features "${{ matrix.feature }},${{ matrix.audio_backend }}_backend"
+        env:
+          RUSTFLAGS: "-C linker=arm-linux-gnueabihf-gcc -L/usr/arm-linux-gnueabihf/lib -L/build/deps_root/usr/lib/arm-linux-gnueabihf -L/build/deps_root/lib/arm-linux-gnueabihf"
+          PKG_CONFIG_ALLOW_CROSS: 1
+          OPENSSL_LIB_DIR: /build/deps_root/usr/lib/arm-linux-gnueabihf
+          OPENSSL_INCLUDE_DIR: /build/deps_root/usr/include/arm-linux-gnueabihf
       - name: Packaging final binary
         shell: bash
         run: |
           cd target/${{ matrix.target }}/release
-          
-          strip spotifyd
           tar czvf spotifyd-${{ matrix.artifact_prefix }}-${{ matrix.artifact_type }}.tar.gz spotifyd
           shasum -a 512 spotifyd-${{ matrix.artifact_prefix }}-${{ matrix.artifact_type }}.tar.gz > spotifyd-${{ matrix.artifact_prefix }}-${{ matrix.artifact_type }}.sha512
-
       - name: Releasing assets
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build_target: [macos, macos-rodio, linux, linux-armhf]
+        build_target: [macos, macos-rodio, linux, linux-armhf, linux-armv6]
         rust: [stable]
         artifact_type: ['slim', 'full']         # The build strategy will build both types for each OS specified
         include:
@@ -39,6 +39,9 @@ jobs:
             artifact_prefix: linux-armhf
             audio_backend: alsa
             target: arm-unknown-linux-gnueabihf
+        exclude:
+          - build_target: linux-armv6
+            artifact_type: 'full'               # Raspberry Pi toolchain is too old for dbus/systemd
 
     steps:
       - name: Installing Rust toolchain
@@ -62,6 +65,19 @@ jobs:
           echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ bionic main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get install -y -qq gcc-arm-linux-gnueabihf libc6-armhf-cross libc6-dev-armhf-cross
+          sudo apt-get download libasound2:armhf libasound2-dev:armhf libssl-dev:armhf libssl1.1:armhf
+          sudo dpkg -x libasound2_*.deb /build/sysroot/
+          sudo dpkg -x libssl-dev*.deb /build/sysroot/
+          sudo dpkg -x libssl1.1*.deb /build/sysroot/
+          sudo dpkg -x libasound2-dev*.deb /build/sysroot/
+      - name: Installing needed Ubuntu armv6 dependencies (slim)
+        if: matrix.os == 'ubuntu-18.04' && matrix.build_target == 'linux-armv6'
+        run: |
+          sudo mkdir -p /build/sysroot
+          echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ bionic main" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
+          sudo apt-get install -y -qq git
+          git -C /build clone --depth=1 https://github.com/raspberrypi/tools.git
           sudo apt-get download libasound2:armhf libasound2-dev:armhf libssl-dev:armhf libssl1.1:armhf
           sudo dpkg -x libasound2_*.deb /build/sysroot/
           sudo dpkg -x libssl-dev*.deb /build/sysroot/
@@ -97,8 +113,8 @@ jobs:
           command: build
           toolchain: ${{ matrix.rust }}
           args: --locked --release --target ${{ matrix.target }} --no-default-features --features "${{ matrix.feature }},${{ matrix.audio_backend }}_backend"
-      - name: Running cargo cross build
-        if: matrix.target == 'arm-unknown-linux-gnueabihf'
+      - name: Running cargo cross build (armhf)
+        if: matrix.build_target == 'linux-armhf'
         uses: actions-rs/cargo@v1
         with:
           command: build
@@ -106,6 +122,19 @@ jobs:
           args: --locked --release --target ${{ matrix.target }} --no-default-features --features "${{ matrix.feature }},${{ matrix.audio_backend }}_backend"
         env:
           RUSTFLAGS: "-C linker=arm-linux-gnueabihf-gcc -L/usr/arm-linux-gnueabihf/lib -L/build/sysroot/usr/lib/arm-linux-gnueabihf -L/build/sysroot/lib/arm-linux-gnueabihf"
+          PKG_CONFIG_ALLOW_CROSS: 1
+          OPENSSL_LIB_DIR: /build/sysroot/usr/lib/arm-linux-gnueabihf
+          OPENSSL_INCLUDE_DIR: /build/sysroot/usr/include/arm-linux-gnueabihf
+      - name: Running cargo cross build (armv6)
+        if: matrix.build_target == 'linux-armv6'
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          toolchain: ${{ matrix.rust }}
+          args: --locked --release --target ${{ matrix.target }} --no-default-features --features "${{ matrix.feature }},${{ matrix.audio_backend }}_backend"
+        env:
+          PATH: "/build/tools/arm-bcm2708/arm-linux-gnueabihf/bin:$PATH"
+          RUSTFLAGS: "-C linker=/build/tools/arm-bcm2708/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc -L/build/tools/arm-bcm2708/arm-linux-gnueabihf/arm-linux-gnueabihf/sysroot/lib -L/build/tools/arm-bcm2708/arm-linux-gnueabihf/arm-linux-gnueabihf/sysroot/usr/lib -L/build/deps_root/usr/lib/arm-linux-gnueabihf -L/build/deps_root/lib/arm-linux-gnueabihf"
           PKG_CONFIG_ALLOW_CROSS: 1
           OPENSSL_LIB_DIR: /build/sysroot/usr/lib/arm-linux-gnueabihf
           OPENSSL_INCLUDE_DIR: /build/sysroot/usr/include/arm-linux-gnueabihf


### PR DESCRIPTION
This PR adds a workflow that creates "arm-unknown-linux-gnueabihf" builds for the "slim" and "full" versions with "alsa_backend" using cross compilation.

The resulting packages are called `spotifyd-linux-armhf-slim.tar.gz` and `spotifyd-linux-armhf-full.tar.gz`.

As a new package source has to be installed, `ubuntu-latest` cannot be used here, so the new step uses `ubuntu-18.04` (which currently is the same, but we need to be sure).

Instead of a full `sbuild` setup, the armhf packages are installed and copied manually, which may look dirty. Unfortunately, `dbus-rs` needs quite some system packages, so we need to download and put them where the linker expects them to be. This process is described here: https://github.com/diwic/dbus-rs/issues/184#issuecomment-520228758

Issues:

- I'm not sure if the binaries produced by this run on the Raspberry Pi 1 (or Zero). To be able to run on these, it might be necessary to use the [arm-bcm2708](https://github.com/raspberrypi/tools/tree/master/arm-bcm2708) linker from raspberrypi/tools, as stated here: https://github.com/BurntSushi/ripgrep/issues/676#issuecomment-374058198
- Can someone test the `full` version? I can build it, but cannot get MPRIS D-Bus running on my machine, which may as well be a client problem: the process refuses to start without `$DISPLAY`, and when using the system dbus, `playerctl` acts up and won't display anything. Not sure if I broke this or it did not work at all in the first place. (If I understand it correctly, starting the `full` version *always* requires D-Bus? #244)

Related: #259, #280, #286