### PR TITLE
fix help message

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -202,8 +202,8 @@ pub struct CliConfig {
     pub shared_config: SharedConfigValues,
 }
 
-/// A struct that holds all allowed config fields.
-/// The actual config file is made up of two sections, spotifyd and global.
+// A struct that holds all allowed config fields.
+// The actual config file is made up of two sections, spotifyd and global.
 #[derive(Clone, Default, Deserialize, PartialEq, StructOpt)]
 pub struct SharedConfigValues {
     /// The Spotify account user name


### PR DESCRIPTION
structopt automatically uses doc comments to create help messages. Moving these comments to normal comments makes them disappear from the `--help` message