### PR TITLE
WIP, do not merge, add support for device-type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ sudo: required
 os: linux
 dist: xenial
 
+branches:
+  only:
+  - /.*/
+
 matrix:
   include:
     - name: "ARM Build"

--- a/src/config.rs
+++ b/src/config.rs
@@ -132,21 +132,18 @@ pub enum DeviceType {
     AudioDongle = 8,
 }
 
-impl FromStr for DeviceType {
-    type Err = ParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use self::DeviceType::*;
-        match s.to_lowercase().as_ref() {
-            "computer" => Ok(Computer),
-            "tablet" => Ok(Tablet),
-            "smartphone" => Ok(Smartphone),
-            "speaker" => Ok(Speaker),
-            "tv" => Ok(TV),
-            "avr" => Ok(AVR),
-            "stb" => Ok(STB),
-            "audiodongle" => Ok(AudioDongle),
-            _ => unreachable!(),
+impl From<LSDeviceType> for DeviceType {
+    fn from(item: LSDeviceType) -> Self {
+        match item {
+            LSDeviceType::Unknown => DeviceType::Unknown,
+            LSDeviceType::Computer => DeviceType::Computer,
+            LSDeviceType::Tablet => DeviceType::Tablet,
+            LSDeviceType::Smartphone => DeviceType::Smartphone,
+            LSDeviceType::Speaker => DeviceType::Speaker,
+            LSDeviceType::TV => DeviceType::TV,
+            LSDeviceType::AVR => DeviceType::AVR,
+            LSDeviceType::STB => DeviceType::STB,
+            LSDeviceType::AudioDongle => DeviceType::AudioDongle,
         }
     }
 }
@@ -164,6 +161,15 @@ impl From<&DeviceType> for LSDeviceType {
             DeviceType::STB => LSDeviceType::STB,
             DeviceType::AudioDongle => LSDeviceType::AudioDongle,
         }
+    }
+}
+
+impl FromStr for DeviceType {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let dt = LSDeviceType::from_str(s).unwrap();
+        Ok(dt.into())
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,7 +117,7 @@ lazy_static! {
         "computer", "tablet", "smartphone", "speaker", "tv", "avr", "stb", "audiodongle"];
 }
 
-/// Spotify's device type (copied from it's config.rs)
+// Spotify's device type (copied from it's config.rs)
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, StructOpt)]
 #[serde(rename_all = "snake_case")]
 pub enum DeviceType {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -86,7 +86,9 @@ pub(crate) fn initial_state(
 
     let zeroconf_port = config.zeroconf_port.unwrap_or(0);
 
+    println!("device_type in: {:?}", config.device_type);
     let device_type: DeviceType = DeviceType::from_str(&config.device_type).unwrap_or(DeviceType::default());
+    println!("device_type out: {:?}", device_type);
 
     #[allow(clippy::or_fun_call)]
     let discovery_stream = discovery(

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -20,6 +20,8 @@ use tokio_signal::ctrl_c;
 
 use std::{io, process::exit};
 
+use std::str::FromStr;
+
 #[cfg(feature = "alsa_backend")]
 use crate::alsa_mixer;
 use crate::{config, main_loop};
@@ -84,12 +86,14 @@ pub(crate) fn initial_state(
 
     let zeroconf_port = config.zeroconf_port.unwrap_or(0);
 
+    let device_type: DeviceType = DeviceType::from_str(&config.device_type).unwrap_or(DeviceType::default());
+
     #[allow(clippy::or_fun_call)]
     let discovery_stream = discovery(
         &handle,
         ConnectConfig {
             name: config.device_name.clone(),
-            device_type: DeviceType::default(),
+            device_type: device_type,
             volume: mixer().volume(),
             linear_volume,
         },


### PR DESCRIPTION
Hi,

As discussed in #450 I have something working. However passing the value to Librespot does not work since spotifyd keeps being listed as Speaker. Any ideas?

```
./spotifyd --no-daemon -d test --device-type smartphone
Loading config from "/home/phablet/.config/spotifyd/spotifyd.conf"
No proxy specified
Using alsa volume controller.
device_type in: "Smartphone"
device_type out: Smartphone
Connecting to AP "gew1-accesspoint-a-ltw9.ap.spotify.com:443"
Authenticated as xxxx !
Using alsa sink
Country: "NL"
```