### PR TITLE
Cleanup code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ url = "1.7"
 xdg = "2.2"
 librespot = { version = "0.1", default-features = false, features = ["with-tremor"] }
 
-[target.'cfg(macos)'.dependencies]
+[target."cfg(target_os = \"macos\")".dependencies]
 whoami = "0.7.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ gethostname = "0.2.0"
 hex = "0.4"
 keyring = { version = "0.7.1", optional = true }
 lazy_static = "1.4.0"
-libc = "0.2"
+libc = "0.2.66"
 log = "0.4.6"
 percent-encoding = "2.1.0"
 rspotify = "0.7.0"
@@ -34,8 +34,10 @@ tokio-io = "0.1"
 tokio-signal = "0.1"
 url = "1.7"
 xdg = "2.2"
-whoami = "0.7.0"
 librespot = { version = "0.1", default-features = false, features = ["with-tremor"] }
+
+[target.'cfg(macos)'.dependencies]
+whoami = "0.7.0"
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,7 @@
 use log::trace;
 use std::env;
+#[cfg(target_os = "macos")]
+use whoami;
 
 #[cfg(target_os = "linux")]
 fn get_shell_ffi() -> Option<String> {
@@ -43,7 +45,6 @@ fn get_shell_ffi() -> Option<String> {
 #[cfg(target_os = "macos")]
 fn get_shell_ffi() -> Option<String> {
     use std::process::Command;
-    use whoami;
 
     trace!("Retrieving user shell through Directory Discovery Services");
 
@@ -62,6 +63,8 @@ fn get_shell_ffi() -> Option<String> {
             return Some(shell.to_string());
         }
     }
+
+    None
 }
 
 pub(crate) fn get_shell() -> Option<String> {
@@ -93,7 +96,7 @@ mod tests {
     fn test_ffi_discovery() {
         init_logger();
 
-        let shell = get_shell();
+        let shell = get_shell_ffi();
         assert_eq!(shell.is_some(), true);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,84 +1,96 @@
-use whoami;
-
+use log::trace;
 use std::env;
 
-pub(crate) fn get_shell() -> Option<String> {
-    // First look for the user's preferred shell using the SHELL environment
-    // variable...
-    if let Ok(shell) = env::var("SHELL") {
-        log::trace!("Found shell {:?} using SHELL environment variable.", shell);
-        return Some(shell);
-    }
+#[cfg(target_os = "linux")]
+fn get_shell_ffi() -> Option<String> {
+    use libc::{geteuid, getpwuid_r};
+    use std::{ffi::CStr, mem, ptr};
 
-    // If the SHELL environment variable is not set and we're on linux or one of the
-    // BSDs, try to obtain the default shell from `/etc/passwd`...
-    #[cfg(not(target_os = "macos"))]
-    {
-        use std::{
-            fs::File,
-            io::{self, BufRead},
+    trace!("Retrieving user shell through libc calls");
+
+    let mut result = ptr::null_mut();
+    unsafe {
+        let amt = match libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) {
+            n if n < 0 => 512 as usize,
+            n => n as usize,
         };
+        let mut buf = Vec::with_capacity(amt);
+        let mut passwd: libc::passwd = mem::zeroed();
 
-        let username = whoami::username();
-
-        let file = File::open("/etc/passwd").ok()?;
-        let reader = io::BufReader::new(file);
-        // Each line of `/etc/passwd` describes a single user and contains seven
-        // colon-separated fields: "name:password:UID:GID:GECOS:directory:shell"
-        for line in reader.lines() {
-            let line = line.ok()?;
-            let mut iter = line.split(':');
-            if let Some(user) = iter.nth(0) {
-                if user == username {
-                    let shell = iter.nth(5)?;
-                    log::trace!("Found shell {:?} using /etc/passwd.", shell);
-                    return Some(shell.into());
-                }
+        match getpwuid_r(
+            geteuid(),
+            &mut passwd,
+            buf.as_mut_ptr(),
+            buf.capacity() as libc::size_t,
+            &mut result
+        ) {
+            0 if !result.is_null() => {
+                let ptr = passwd.pw_shell as *const _;
+                let shell = CStr::from_ptr(ptr).to_str().expect("Failed to retrieve shell").to_owned();
+                Some(shell)
             }
+            _ => None
         }
     }
+}
 
-    // If the SHELL environment variable is not set and on we're on macOS,
-    // query the Directory Service command line utility (dscl) for the user's shell,
-    // as macOS does not use the /etc/passwd file...
-    #[cfg(target_os = "macos")]
-    {
-        use std::process::Command;
+// If the SHELL environment variable is not set and on we're on macOS,
+// query the Directory Service command line utility (dscl) for the user's shell,
+// as macOS does not use the /etc/passwd file
+#[cfg(target_os = "macos")]
+fn get_shell_ffi() -> Option<String> {
+    use std::process::Command;
+    use whoami;
 
-        let username = whoami::username();
-        let output = Command::new("dscl")
-            .args(&[".", "-read", &format!("/Users/{}", username), "UserShell"])
-            .output()
-            .ok()?;
-        if output.status.success() {
-            let stdout = std::str::from_utf8(&output.stdout).ok()?;
-            // The output of this dscl command should be:
-            // "UserShell: /path/to/shell"
-            if stdout.starts_with("UserShell: ") {
-                let shell = stdout.split_whitespace().nth(1)?;
-                log::trace!("Found shell {:?} using dscl command.", shell);
-                return Some(shell.to_string());
-            }
+    trace!("Retrieving user shell through Directory Discovery Services");
+
+    let username = whoami::username();
+    let output = Command::new("dscl")
+        .args(&[".", "-read", &format!("/Users/{}", username), "UserShell"])
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let stdout = std::str::from_utf8(&output.stdout).ok()?;
+        // The output of the dscl command should be:
+        // "UserShell: /path/to/shell"
+        if stdout.starts_with("UserShell: ") {
+            let shell = stdout.split_whitespace().nth(1)?;
+            return Some(shell.to_string())
         }
     }
-    None
+}
+
+pub(crate) fn get_shell() -> Option<String> {
+    let shell = env::var("SHELL").ok().or_else(get_shell_ffi);
+    trace!("Found user shell: {:?}", &shell);
+
+    shell
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn init_logger() {
+        let _ = env_logger::builder().is_test(true).try_init();
+    }
+
     #[test]
-    fn it_works() {
-        env::set_var("RUST_LOG", "spotifyd=trace");
+    fn test_envvar_discovery() {
+        init_logger();
 
-        env_logger::init();
+        env::set_var("SHELL", "fantasy_shell");
 
-        let _ = get_shell().unwrap();
+        let shell = get_shell().unwrap();
+        assert_eq!(shell, "fantasy_shell");
+    }
 
-        if env::var("SHELL").is_ok() {
-            env::remove_var("SHELL");
-            let _ = get_shell().unwrap();
-        }
+    #[test]
+    fn test_ffi_discovery() {
+        init_logger();
+
+        let shell = get_shell();
+        assert_eq!(shell.is_some(), true);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,14 +22,17 @@ fn get_shell_ffi() -> Option<String> {
             &mut passwd,
             buf.as_mut_ptr(),
             buf.capacity() as libc::size_t,
-            &mut result
+            &mut result,
         ) {
             0 if !result.is_null() => {
                 let ptr = passwd.pw_shell as *const _;
-                let shell = CStr::from_ptr(ptr).to_str().expect("Failed to retrieve shell").to_owned();
+                let shell = CStr::from_ptr(ptr)
+                    .to_str()
+                    .expect("Failed to retrieve shell")
+                    .to_owned();
                 Some(shell)
             }
-            _ => None
+            _ => None,
         }
     }
 }
@@ -56,7 +59,7 @@ fn get_shell_ffi() -> Option<String> {
         // "UserShell: /path/to/shell"
         if stdout.starts_with("UserShell: ") {
             let shell = stdout.split_whitespace().nth(1)?;
-            return Some(shell.to_string())
+            return Some(shell.to_string());
         }
     }
 }


### PR DESCRIPTION
Cleans up the shell discovery code a little bit by relying on system function calls instead of parsing the `/etc/passwd` file on linux devices.