### PR TITLE
chore(git): add git pre-commit and setup script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 ## Setup
 
+__Important:__ Make sure to install the provided git hooks by running `setup-dev-workspace.sh`! 
+
 ### Install Rust
 
 It is recommended to install rust through [rustup](https://rustup.rs). System package managers often have outdated versions of Rust or don't include rustfmt/clippy.

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Author: Sven Lechner (SirWindfield)
+# License: GPLv3
+
+require_clean_work_tree() {
+    # Update index
+    git update-index -q --ignore-submodules --refresh
+    err=0
+
+    # Disallow unstaged changes in the working tree
+    if ! git diff-files --quiet --ignore-submodules --; then
+        echo >&2 "Cannot commit: you have unstaged changes."
+        git diff-files --name-status -r --ignore-submodules -- >&2
+        err=1
+    fi
+
+    if [ $err = 1 ]; then
+        echo >&2 "Please stage or stash them."
+        exit 1
+    fi
+}
+
+echo "→ Checking for local changes..."
+require_clean_work_tree
+
+echo "→ Formatting Rust code..."
+cargo fmt
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+
+for path in $(git diff --name-only --cached); do
+    git update-index --add $path
+done
+
+echo "→ Building pre-commit build artifacts..."
+cargo check --quiet --no-default-features --features "rodio_backend,dbus_keyring"
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+cargo build --quiet --no-default-features --features "rodio_backend,dbus_keyring"
+
+# Linting is only done with the rodio backend and the keyring feature as those should be 
+# compilable for every supported platform without external library needs. 
+echo "→ Linting Rust code..."
+cargo clippy --no-default-features --features "rodio_backend,dbus_keyring" -- -D warnings
+
+echo "→ Testing Rust code..."
+cargo test --no-default-features --features "rodio_backend,dbus_keyring"

--- a/setup-dev-workspace.sh
+++ b/setup-dev-workspace.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Author: Sven Lechner (SirWindfield)
+# License: GPLv3
+
+# Copies all hooks into the .git/hooks directory
+cp hooks/* .git/hooks


### PR DESCRIPTION
The pre-commit hook ensures multiple things before commiting code:

1) All Rust code is properly formatted
2) All linting errors are fixed
3) All tests are passing
4) The project can be compiled inside of the local development env