### PR TITLE
Remove notes on closed issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,7 @@ On Linux you will need the development package for alsa and make/gcc. (`libasoun
 
 ## Configuration
 
-`Spotifyd` is able to run without configuration at all and will assume default values for most of the fields. However, running without configuration will only allow you to connect to it if you're on the same network as the daemon.
-
-> __Note:__ This is currently not possible anymore and under investigation. For more information and updates, take a look at #366.
+`Spotifyd` is able to run without configuration at all and will assume default values for most of the fields. However, running without configuration will only allow you to connect to it via Spotify Connect if you're on the same network as the daemon.
 
 ### CLI options
 
@@ -343,7 +341,6 @@ Note:
 
 - Spotifyd will not work without Spotify Premium
 - The device name cannot contain spaces
-- Launching in discovery mode (username and password left empty) makes the daemon undiscoverable from within the app (tracking issue #373)
 
 ## Contributing
 


### PR DESCRIPTION
`README.md` mentions problems with the Spotify Connect functionality (also called discovery mode). It seems that the problems are resolved: issues are closed and I confirm that I am able to use the functionality with the current spotifyd version (0.2.24).

This PR removes the note about the past issues from the `README.md` file.

Have a nice day!