### PR TITLE
[WIP]: fix shell script lints

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -24,8 +24,7 @@ echo "→ Checking for local changes..."
 require_clean_work_tree
 
 echo "→ Formatting Rust code..."
-cargo fmt
-if [ $? -ne 0 ]; then
+if ! cargo fmt; then
     exit 1
 fi
 
@@ -34,8 +33,7 @@ for path in $(git diff --name-only --cached); do
 done
 
 echo "→ Building pre-commit build artifacts..."
-cargo check --quiet --no-default-features --features "rodio_backend,dbus_keyring"
-if [ $? -ne 0 ]; then
+if ! cargo check --quiet --no-default-features --features "rodio_backend,dbus_keyring"; then
     exit 1
 fi
 cargo build --quiet --no-default-features --features "rodio_backend,dbus_keyring"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -30,7 +30,7 @@ if [ $? -ne 0 ]; then
 fi
 
 for path in $(git diff --name-only --cached); do
-    git update-index --add $path
+    git update-index --add "$path"
 done
 
 echo "→ Building pre-commit build artifacts..."


### PR DESCRIPTION
This fixes some `spellcheck` lints. I can't test linux/posix related stuff right now due to a bug inside of WSL and I don't really want to merge untested stuff (even though this is a simple change). But I never used this `sh` syntax so I am actually not 100% sure that it works as expected.

If someone could try the script or (honestly) confirm that this works indeed as it should (take a look at the file diffs), then I'd be willing to merge it.