### PR TITLE
fix: Cannot start playback on device running spotifyd without a Spoti…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "rspotify"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2564,7 +2564,7 @@ dependencies = [
  "librespot 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rspotify 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rspotify 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_ini 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3612,7 +3612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum result 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "194d8e591e405d1eecf28819740abed6d719d1a2db87fc0bcdedee9a26d55560"
 "checksum rodio 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d0f961b254e66d147a7b550c78b01308934c97d807a34b417fd0f5a0a0f3a2d"
 "checksum rpassword 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c34fa7bcae7fca3c8471e8417088bbc3ad9af8066b0ecf4f3c0d98a0d772716e"
-"checksum rspotify 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a924a166cfb1315c8d9c89148e438a1337feb655ce052fc6dc952af8018bad93"
+"checksum rspotify 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eefd7bb58b714606b30a490f751d7926942e2874eef5e82934d60d7a4a68dca4"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lazy_static = "1.4.0"
 libc = "0.2.67"
 log = "0.4.6"
 percent-encoding = "2.1.0"
-rspotify = "0.8.0"
+rspotify = { version = "0.10.0", features=["blocking"]}
 serde = { version = "1.0.111", features = ["derive"] }
 serde_ini = "0.2.0"
 sha-1 = "0.9"

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -76,7 +76,6 @@ impl Future for DbusServer {
     type Item = ();
 
     fn poll(&mut self) -> Poll<(), ()> {
-        let mut got_new_token = false;
         if self.is_token_expired() {
             if let Some(ref mut fut) = self.token_request {
                 if let Async::Ready(token) = fut.poll().unwrap() {
@@ -90,7 +89,7 @@ impl Future for DbusServer {
                         self.spirc.clone(),
                         self.device_name.clone(),
                     ));
-                    got_new_token = true;
+                    self.token_request = None;
                 }
             } else {
                 // This is more meant as a fast hotfix than anything else!
@@ -101,10 +100,6 @@ impl Future for DbusServer {
         }
         if let Some(ref mut fut) = self.dbus_future {
             return fut.poll();
-        }
-
-        if got_new_token {
-            self.token_request = None;
         }
 
         Ok(Async::NotReady)


### PR DESCRIPTION
…fy client

update rspotify to 0.10.0
activate dbus as soon as authentication succeeds
correctly retrieve device by name
transfer playback to current device on playback

Fixes #609