### PR TITLE
chore(readme): add `cargo install` to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ To install the resulting binary, run
 cargo install --path . --locked
 ```
 
+### Installing with Cargo
+
+If you have `cargo` installed, you can directly install `spotifyd` by running:
+
+```bash
+cargo install spotifyd --locked
+```
+
+That will compile and install `spotifyd`'s latest version under `$HOME/.cargo/bin` for you.
+
 #### Building a Debian package
 
 You can use the `cargo-deb` create in order to build a Debian package from source.


### PR DESCRIPTION
As stated in #563, `cargo install spotifyd` does not compile
successfully due to a compilation error caused by `librespot`.

In order to solve this, it was mentioned in librespot-org/librespot#477
that adding the `--locked` file solves the problem since it is
preventing some of their dependencies to change and keep fixed.

Therefore, if we use `cargo` to install `spotifyd` it is necessary
for the time being to use the `--locked` file too.

- Added `Installing with Cargo` section in README.md with this
commad specs.

Closes #563 partially, since a better solution should be found
in the future.


I wonder if it is possible (I've never seen it) to add the `--locked` flag in the `Cargo.toml` for `librespot` similar to:
```toml
librespot = { version = "0.1.1", default-features = false, features = ["with-tremor"], flags = "locked"}
```

If anyone knows, that might be better than adding the `--locked` flag directly in the `spotifyd` installation.