### PR TITLE
Introduce use_mpris configuration setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,9 +200,10 @@ use_keyring = true
 
 #
 # If set to true, `spotifyd` tries to bind to the session dbus
-# and expose MPRIS controls
+# and expose MPRIS controls. When running headless, without a dbus session,
+# then set this to false to avoid binding errors
 #
-use_mpris = false
+use_mpris = true
 
 # The audio backend used to play the your music. To get
 # a list of possible backends, run `spotifyd --help`.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ password_cmd = "command_that_writes_password_to_stdout"
 # can't be used simultaneously.
 use_keyring = true
 
+#
+# If set to true, `spotifyd` tries to bind to the session dbus
+# and expose MPRIS controls
+#
+use_mpris = false
+
 # The audio backend used to play the your music. To get
 # a list of possible backends, run `spotifyd --help`.
 backend = "alsa"

--- a/src/config.rs
+++ b/src/config.rs
@@ -623,14 +623,11 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         .unwrap_or(DeviceType::Speaker)
         .to_string();
 
-    let pid = config
-        .pid
-        .map(|f| {
-            f.into_os_string()
-                .into_string()
-                .expect("Failed to convert PID file path to valid Unicode")
-        })
-        .or_else(|| None);
+    let pid = config.pid.map(|f| {
+        f.into_os_string()
+            .into_string()
+            .expect("Failed to convert PID file path to valid Unicode")
+    });
 
     let shell = utils::get_shell().unwrap_or_else(|| {
         info!("Unable to identify shell. Defaulting to \"sh\".");

--- a/src/config.rs
+++ b/src/config.rs
@@ -510,7 +510,8 @@ impl SharedConfigValues {
             on_song_change_hook,
             zeroconf_port,
             proxy,
-            device_type
+            device_type,
+            use_mpris
         );
 
         // Handles boolean merging.

--- a/src/config.rs
+++ b/src/config.rs
@@ -280,7 +280,7 @@ pub struct SharedConfigValues {
         serde(alias = "use-mpris", default)
     )]
     #[cfg_attr(not(feature = "dbus_mpris"), structopt(skip), serde(skip))]
-    use_mpris: bool,
+    use_mpris: Option<bool>,
 
     /// A command that can be used to retrieve the Spotify account password
     #[structopt(
@@ -676,7 +676,7 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         username,
         password,
         use_keyring: config.shared_config.use_keyring,
-        use_mpris: config.shared_config.use_mpris,
+        use_mpris: config.shared_config.use_mpris.unwrap_or(true),
         cache,
         backend: Some(backend),
         audio_device: config.shared_config.device,

--- a/src/config.rs
+++ b/src/config.rs
@@ -274,6 +274,14 @@ pub struct SharedConfigValues {
     #[cfg_attr(not(feature = "dbus_keyring"), structopt(skip), serde(skip))]
     use_keyring: bool,
 
+    #[cfg_attr(
+        feature = "dbus_mpris",
+        structopt(long),
+        serde(alias = "use-mpris", default)
+    )]
+    #[cfg_attr(not(feature = "dbus_mpris"), structopt(skip), serde(skip))]
+    use_mpris: bool,
+
     /// A command that can be used to retrieve the Spotify account password
     #[structopt(
         conflicts_with = "password",
@@ -426,6 +434,7 @@ impl fmt::Debug for SharedConfigValues {
             .field("password", &password_value)
             .field("password_cmd", &password_cmd_value)
             .field("use_keyring", &self.use_keyring)
+            .field("use_mpris", &self.use_mpris)
             .field("on_song_change_hook", &self.on_song_change_hook)
             .field("cache_path", &self.cache_path)
             .field("no-audio-cache", &self.no_audio_cache)
@@ -534,6 +543,7 @@ pub(crate) struct SpotifydConfig {
     pub(crate) password: Option<String>,
     #[allow(unused)]
     pub(crate) use_keyring: bool,
+    pub(crate) use_mpris: bool,
     pub(crate) cache: Option<Cache>,
     pub(crate) backend: Option<String>,
     pub(crate) audio_device: Option<String>,
@@ -669,6 +679,7 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         username,
         password,
         use_keyring: config.shared_config.use_keyring,
+        use_mpris: config.shared_config.use_mpris,
         cache,
         backend: Some(backend),
         audio_device: config.shared_config.device,

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -99,6 +99,7 @@ pub(crate) struct MainLoopState {
     pub(crate) running_event_program: Option<Child>,
     pub(crate) shell: String,
     pub(crate) device_type: DeviceType,
+    pub(crate) use_mpris: bool,
 }
 
 impl Future for MainLoopState {
@@ -179,12 +180,14 @@ impl Future for MainLoopState {
                 let shared_spirc = Rc::new(spirc);
                 self.librespot_connection.spirc = Some(shared_spirc.clone());
 
-                self.spotifyd_state.dbus_mpris_server = new_dbus_server(
-                    session,
-                    self.handle.clone(),
-                    shared_spirc,
-                    self.spotifyd_state.device_name.clone(),
-                );
+                if self.use_mpris {
+                    self.spotifyd_state.dbus_mpris_server = new_dbus_server(
+                        session,
+                        self.handle.clone(),
+                        shared_spirc,
+                        self.spotifyd_state.device_name.clone(),
+                    );
+                }
             } else if let Async::Ready(_) = self.spotifyd_state.ctrl_c_stream.poll().unwrap() {
                 if !self.spotifyd_state.shutting_down {
                     if let Some(ref spirc) = self.librespot_connection.spirc {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -155,6 +155,7 @@ pub(crate) fn initial_state(
         shell: config.shell,
         device_type,
         autoplay,
+        use_mpris: config.use_mpris,
     }
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -40,7 +40,10 @@ pub(crate) fn initial_state(
             }
             _ => {
                 info!("Using alsa volume controller.");
-                let linear = matches!(config.volume_controller, config::VolumeController::AlsaLinear);
+                let linear = matches!(
+                    config.volume_controller,
+                    config::VolumeController::AlsaLinear
+                );
                 Box::new(move || {
                     Box::new(alsa_mixer::AlsaMixer {
                         device: local_control_device
@@ -69,9 +72,12 @@ pub(crate) fn initial_state(
     let autoplay = config.autoplay;
     let device_id = session_config.device_id.clone();
 
-    #[cfg(feature = "alsa_backend")]  
-    let linear_volume = matches!(config.volume_controller, config::VolumeController::AlsaLinear);
-                
+    #[cfg(feature = "alsa_backend")]
+    let linear_volume = matches!(
+        config.volume_controller,
+        config::VolumeController::AlsaLinear
+    );
+
     #[cfg(not(feature = "alsa_backend"))]
     let linear_volume = false;
 


### PR DESCRIPTION
#730 

This defines the `use_mpris` configuration setting in the main
configuration file. Set this to `false` in case you have a headless
`spotifyd` instance, running in session lacking a dbus session.