### PR TITLE
Remove `failure' as a dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,7 +2862,6 @@ dependencies = [
  "dbus 0.6.5",
  "dbus-tokio",
  "env_logger 0.7.1",
- "failure",
  "fern",
  "futures 0.1.29",
  "gethostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ chrono = "0.4"
 daemonize = "0.4"
 dbus = { version = "0.6", optional = true }
 dbus-tokio = { version = "0.2", optional = true }
-failure = "0.1.7"
 fern = { version = "0.6.0", features = ["syslog-4"] }
 futures = "0.1"
 gethostname = "0.2.0"


### PR DESCRIPTION
Refer to https://github.com/Spotifyd/spotifyd/pull/627#issuecomment-709347897; `failure` was not actually used, and is deprecated anyway, so this MR removes references to it in Cargo.toml and Cargo.lock.

Closes #627.