### PR TITLE
Remove "looking for maintainers"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # Spotifyd <!-- omit in toc -->
----
-Looking for maintainers!
----
 ![Cargo Downloads](https://img.shields.io/crates/d/spotifyd)
 [![Dependabot Status][dependabot-badge]](https://dependabot.com)
 [![Github Actions - CD][cd-badge]][github-actions]


### PR DESCRIPTION
Since we already have enough maintainers as for now, I think we can remove the "Looking for maintainers" note from the Readme.