### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -100,11 +100,12 @@ jobs:
           sudo dpkg -x libssl-dev*.deb /build/sysroot/
           sudo dpkg -x libssl1.1*.deb /build/sysroot/
           sudo dpkg -x libasound2-dev*.deb /build/sysroot/
-          echo "::set-env name=PKG_CONFIG_ALLOW_CROSS::1"
-          echo "::set-env name=RUSTFLAGS::-C linker=arm-linux-gnueabihf-gcc -L/usr/arm-linux-gnueabihf/lib -L/build/sysroot/usr/lib/arm-linux-gnueabihf -L/build/sysroot/lib/arm-linux-gnueabihf"
-          echo "::set-env name=C_INCLUDE_PATH::/build/sysroot/usr/include"
-          echo "::set-env name=OPENSSL_LIB_DIR::/build/sysroot/usr/lib/arm-linux-gnueabihf"
-          echo "::set-env name=OPENSSL_INCLUDE_DIR::/build/sysroot/usr/include/arm-linux-gnueabihf"
+          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
+          echo "TEST=abc" >> $GITHUB_ENV
+          echo "RUSTFLAGS=-C linker=arm-linux-gnueabihf-gcc -L/usr/arm-linux-gnueabihf/lib -L/build/sysroot/usr/lib/arm-linux-gnueabihf -L/build/sysroot/lib/arm-linux-gnueabihf" >> $GITHUB_ENV
+          echo "C_INCLUDE_PATH=/build/sysroot/usr/include" >> $GITHUB_ENV
+          echo "OPENSSL_LIB_DIR=/build/sysroot/usr/lib/arm-linux-gnueabihf" >> $GITHUB_ENV
+          echo "OPENSSL_INCLUDE_DIR=/build/sysroot/usr/include/arm-linux-gnueabihf" >> $GITHUB_ENV
       - name: Installing needed Ubuntu armv6 dependencies
         if: matrix.os == 'ubuntu-18.04' && matrix.build_target == 'linux-armv6'
         run: |
@@ -118,12 +119,13 @@ jobs:
           sudo dpkg -x libssl-dev*.deb /build/sysroot/
           sudo dpkg -x libssl1.1*.deb /build/sysroot/
           sudo dpkg -x libasound2-dev*.deb /build/sysroot/
-          echo "::add-path::/build/tools/arm-bcm2708/arm-linux-gnueabihf/bin"
-          echo "::set-env name=PKG_CONFIG_ALLOW_CROSS::1"
-          echo "::set-env name=RUSTFLAGS::-C linker=/build/tools/arm-bcm2708/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc -L/build/tools/arm-bcm2708/arm-linux-gnueabihf/arm-linux-gnueabihf/sysroot/lib -L/build/tools/arm-bcm2708/arm-linux-gnueabihf/arm-linux-gnueabihf/sysroot/usr/lib -L/build/sysroot/usr/lib/arm-linux-gnueabihf -L/build/sysroot/lib/arm-linux-gnueabihf"
-          echo "::set-env name=C_INCLUDE_PATH::/build/sysroot/usr/include"
-          echo "::set-env name=OPENSSL_LIB_DIR::/build/sysroot/usr/lib/arm-linux-gnueabihf"
-          echo "::set-env name=OPENSSL_INCLUDE_DIR::/build/sysroot/usr/include/arm-linux-gnueabihf"
+          echo "/build/tools/arm-bcm2708/arm-linux-gnueabihf/bin" >> $GITHUB_PATH
+          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
+          echo "TEST=abcd" >> $GITHUB_ENV
+          echo "RUSTFLAGS=-C linker=/build/tools/arm-bcm2708/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc -L/build/tools/arm-bcm2708/arm-linux-gnueabihf/arm-linux-gnueabihf/sysroot/lib -L/build/tools/arm-bcm2708/arm-linux-gnueabihf/arm-linux-gnueabihf/sysroot/usr/lib -L/build/sysroot/usr/lib/arm-linux-gnueabihf -L/build/sysroot/lib/arm-linux-gnueabihf" >> $GITHUB_ENV
+          echo "C_INCLUDE_PATH=/build/sysroot/usr/include" >> $GITHUB_ENV
+          echo "OPENSSL_LIB_DIR=/build/sysroot/usr/lib/arm-linux-gnueabihf" >> $GITHUB_ENV
+          echo "OPENSSL_INCLUDE_DIR=/build/sysroot/usr/include/arm-linux-gnueabihf" >> $GITHUB_ENV
       - name: Installing needed Ubuntu armhf dependencies (full)
         if: matrix.os == 'ubuntu-18.04' && matrix.build_target == 'linux-armhf' && matrix.artifact_type != 'slim'
         run: |


### PR DESCRIPTION
as stated in the error message the old way of setting env variables dont work anymore, migrated according to https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

But now there is a new error: https://github.com/robinvd/spotifyd/runs/1691646667. Ill look at it tomorrow, or if anyone else finds it feel free to use this as a base

EDIT: original error https://github.com/Spotifyd/spotifyd/runs/1691450075