### PR TITLE
also pin rust version on CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         build_target: [macos, linux, linux-armhf, linux-armv6]
-        rust: [stable]
+        rust: [1.47.0]
         artifact_type: ['slim', 'default', 'full']  # The build strategy will build all types for each OS specified
         include:
           - artifact_type: 'slim'               # Slim version has no features enabled by default.


### PR DESCRIPTION
in reply to this comment https://github.com/Spotifyd/spotifyd/issues/719#issuecomment-760148418

tested on my [fork](https://github.com/Spotifyd/spotifyd/runs/1701099531) and says it now uses the correct version, just like the last one this PR should also be reverted when it is fixed.

After this we can make a PR to push a new version/tag with 0.3 (https://github.com/Spotifyd/spotifyd/issues/765#issuecomment-760146839)