### PR TITLE
bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2854,7 +2854,7 @@ checksum = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 
 [[package]]
 name = "spotifyd"
-version = "0.2.25"
+version = "0.3.0"
 dependencies = [
  "alsa 0.3.0",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "spotifyd"
 description = "A Spotify daemon"
 repository = "https://github.com/Spotifyd/spotifyd"
 license = "GPL-3.0-only"
-version = "0.2.25"
+version = "0.3.0"
 
 [dependencies]
 alsa = { version = "0.3", optional = true }


### PR DESCRIPTION
after this we can create a new tag with 0.3.0 and push to crates.io 