### PR TITLE
Improve 'Compiling from source' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ You can also compile `Spotifyd` yourself, allowing you to make use of feature fl
 
 | Target Platform | Libraries                                            |
 |-----------------|------------------------------------------------------|
-| Fedora          | alsa-lib-devel, make, gcc                            |
-| openSUSE        | alsa-devel, make, gcc                                |
+| Fedora          | alsa-lib-devel make gcc                              |
+| openSUSE        | alsa-devel make gcc                                  |
 | Debian          | libasound2-dev libssl-dev libpulse-dev libdbus-1-dev |
-| macOS           | dbus, pkg-config, portaudio                          |
+| Arch            | base-devel alsa-lib libogg libpulse dbus             |
+| macOS           | dbus pkg-config portaudio                            |
 
 > __Note:__ The package names for Linux are the ones used on Debian based distributions (like Ubuntu). You will need to adapt the packages for your distribution respectively.
 


### PR DESCRIPTION
- Make library-table consistent.
- Add dependencies for people trying to compile it on Arch(based) distros, in case they don't use AUR.

 I decided to remove all commas, since its easier to copy/paste and use them as arguments for the used package manager.