### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,7 @@ use std::env;
 #[cfg(target_os = "macos")]
 use whoami;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "freebsd", target_os = "linux"))]
 fn get_shell_ffi() -> Option<String> {
     use libc::{geteuid, getpwuid_r};
     use std::{ffi::CStr, mem, ptr};


### PR DESCRIPTION
Fix:
```
error[E0425]: cannot find value `get_shell_ffi` in this scope                                                                                                              
  --> src/utils.rs:71:48                                                                                                                                                   
   |                                                                                                                                                                       
71 |     let shell = env::var("SHELL").ok().or_else(get_shell_ffi);                                                                                                        
   |                                                ^^^^^^^^^^^^^ not found in this scope
```