### PR TITLE
Refactor Config structs according to features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3082,6 +3082,7 @@ name = "spotifyd"
 version = "0.3.0"
 dependencies = [
  "alsa 0.3.0",
+ "cfg-if 1.0.0",
  "chrono",
  "color-eyre",
  "daemonize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ xdg = "2.2"
 librespot = { version = "0.1.1", default-features = false, features = ["with-tremor"] }
 toml = "0.5.8"
 color-eyre = "0.5"
+cfg-if = "1"
 
 [target."cfg(target_os = \"macos\")".dependencies]
 whoami = "0.9.0"

--- a/docs/src/config/File.md
+++ b/docs/src/config/File.md
@@ -42,13 +42,19 @@ backend = "alsa"
 
 # The alsa audio device to stream audio to. To get a
 # list of valid devices, run `aplay -L`,
+#
+# Comment out or remove if you are not using the `alsa_backend`.
 device = "alsa_audio_device"  # omit for macOS
 
 # The alsa control device. By default this is the same
 # name as the `device` field.
+#
+# Comment out or remove if you are not using the `alsa_backend`.
 control = "alsa_audio_device"  # omit for macOS
 
 # The alsa mixer used by `spotifyd`.
+#
+# Comment out or remove if you are not using the `alsa_backend`.
 mixer = "PCM"
 
 # The volume controller. Each one behaves different to
@@ -114,7 +120,7 @@ device_type = "speaker"
 
 - **`use_keyring`** config entry / **`--use-keyring`** CLI flag <!-- omit in toc -->
 
-  This features leverages [Linux's DBus Secret Service API][secret-storage-specification] or native macOS keychain in order to forgo the need to store your password directly in the config file. To use it, complile with the `dbus_keyring` feature and set the `use-keyring` config entry to `true` or pass the `--use-keyring` CLI flag  during start to the daemon. Remove the `password` and/or `password_cmd` config entries.
+  This features leverages [Linux's DBus Secret Service API][secret-storage-specification] or native macOS keychain in order to forgo the need to store your password directly in the config file. To use it, complile with the `dbus_keyring` feature and set the `use-keyring` config entry to `true` or pass the `--use-keyring` CLI flag during start to the daemon. Remove the `password` and/or `password_cmd` config entries.
 
   Your keyring entry needs to have the following attributes set:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -317,19 +317,19 @@ pub struct SharedConfigValues {
     volume_controller: Option<VolumeController>,
 
     /// The audio device
-    #[cfg(feature = "alsa-backend")]
+    #[cfg(feature = "alsa_backend")]
     #[structopt(long, value_name = "string")]
-    device: String,
+    device: Option<String>,
 
     /// The control device
-    #[cfg(feature = "alsa-backend")]
+    #[cfg(feature = "alsa_backend")]
     #[structopt(long, value_name = "string")]
-    control: String,
+    control: Option<String>,
 
     /// The mixer to use
-    #[cfg(feature = "alsa-backend")]
+    #[cfg(feature = "alsa_backend")]
     #[structopt(long, value_name = "string")]
-    mixer: String,
+    mixer: Option<String>,
 
     /// The device name displayed in Spotify
     #[structopt(long, short, value_name = "string")]
@@ -454,7 +454,7 @@ impl fmt::Debug for SharedConfigValues {
             .field("proxy", &self.proxy)
             .field("device_type", &self.device_type);
         cfg_if::cfg_if! {
-            if #[cfg(feature = "alsa-backend")] {
+            if #[cfg(feature = "alsa_backend")] {
                 deb_struct
                 .field("device", &self.device)
                 .field("control", &self.control)
@@ -524,7 +524,7 @@ impl SharedConfigValues {
             use_mpris
         );
 
-        #[cfg(feature = "alsa-backend")]
+        #[cfg(feature = "alsa_backend")]
         merge!(mixer, control, device);
 
         // Handles boolean merging.
@@ -560,12 +560,12 @@ pub(crate) struct SpotifydConfig {
     pub(crate) use_mpris: bool,
     pub(crate) cache: Option<Cache>,
     pub(crate) backend: Option<String>,
-    #[cfg(feature = "alsa-backend")]
-    pub(crate) audio_device: String,
-    #[cfg(feature = "alsa-backend")]
-    pub(crate) control_device: String,
-    #[cfg(feature = "alsa-backend")]
-    pub(crate) mixer: String,
+    #[cfg(feature = "alsa_backend")]
+    pub(crate) audio_device: Option<String>,
+    #[cfg(feature = "alsa_backend")]
+    pub(crate) control_device: Option<String>,
+    #[cfg(feature = "alsa_backend")]
+    pub(crate) mixer: Option<String>,
     pub(crate) volume_controller: VolumeController,
     pub(crate) initial_volume: Option<u16>,
     pub(crate) device_name: String,
@@ -693,11 +693,11 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         use_mpris: config.shared_config.use_mpris.unwrap_or(true),
         cache,
         backend: Some(backend),
-        #[cfg(feature = "alsa-backend")]
+        #[cfg(feature = "alsa_backend")]
         audio_device: config.shared_config.device,
-        #[cfg(feature = "alsa-backend")]
+        #[cfg(feature = "alsa_backend")]
         control_device: config.shared_config.control,
-        #[cfg(feature = "alsa-backend")]
+        #[cfg(feature = "alsa_backend")]
         mixer: config.shared_config.mixer,
         volume_controller,
         initial_volume,
@@ -752,7 +752,7 @@ mod tests {
         assert_eq!(merged_config, spotifyd_section);
     }
 
-    #[cfg(features = "alsa-backend")]
+    #[cfg(features = "alsa_backend")]
     #[test]
     fn test_section_merging() {
         let mut spotifyd_section = SharedConfigValues::default();

--- a/src/config.rs
+++ b/src/config.rs
@@ -751,4 +751,27 @@ mod tests {
         spotifyd_section.username = Some("testUserName".to_string());
         assert_eq!(merged_config, spotifyd_section);
     }
+
+    #[cfg(features = "alsa-backend")]
+    #[test]
+    fn test_section_merging() {
+        let mut spotifyd_section = SharedConfigValues::default();
+        global_section.mixer = "PCM".to_string();
+
+        let global_section = SharedConfigValues::default();
+        global_section.mixer = "PCM1".to_string();
+
+        // The test only makes sense if both sections differ.
+        assert!(spotifyd_section != global_section, true);
+
+        let file_config = FileConfig {
+            global: Some(global_section),
+            spotifyd: Some(spotifyd_section.clone()),
+        };
+        let merged_config = file_config.get_merged_sections().unwrap();
+
+        // Add the new field to spotifyd section.
+        spotifyd_section.mixer = "PMC".to_string();
+        assert_eq!(merged_config, spotifyd_section);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -505,52 +505,27 @@ impl SharedConfigValues {
             }
         }
 
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "alsa-backend")] {
-                merge!(
-                    backend,
-                    username,
-                    username_cmd,
-                    password,
-                    password_cmd,
-                    normalisation_pregain,
-                    bitrate,
-                    initial_volume,
-                    device_name,
-                    mixer,
-                    control,
-                    device,
-                    volume_controller,
-                    cache_path,
-                    on_song_change_hook,
-                    zeroconf_port,
-                    proxy,
-                    device_type,
-                    use_mpris
-                );
-            } else {
-                merge!(
-                    backend,
-                    username,
-                    username_cmd,
-                    password,
-                    password_cmd,
-                    normalisation_pregain,
-                    bitrate,
-                    initial_volume,
-                    device_name,
-                    volume_controller,
-                    cache_path,
-                    on_song_change_hook,
-                    zeroconf_port,
-                    proxy,
-                    device_type,
-                    use_mpris
-                );
-            }
-        }
+        merge!(
+            backend,
+            username,
+            username_cmd,
+            password,
+            password_cmd,
+            normalisation_pregain,
+            bitrate,
+            initial_volume,
+            device_name,
+            volume_controller,
+            cache_path,
+            on_song_change_hook,
+            zeroconf_port,
+            proxy,
+            device_type,
+            use_mpris
+        );
 
-        // Handles Option<T> merging.
+        #[cfg(feature = "alsa-backend")]
+        merge!(mixer, control, device);
 
         // Handles boolean merging.
         self.use_keyring |= other.use_keyring;

--- a/src/config.rs
+++ b/src/config.rs
@@ -566,6 +566,7 @@ pub(crate) struct SpotifydConfig {
     pub(crate) control_device: Option<String>,
     #[cfg(feature = "alsa_backend")]
     pub(crate) mixer: Option<String>,
+    #[cfg_attr(not(feature = "alsa_backend"), allow(dead_code))]
     pub(crate) volume_controller: VolumeController,
     pub(crate) initial_volume: Option<u16>,
     pub(crate) device_name: String,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -141,10 +141,17 @@ pub(crate) fn initial_state(
     let backend = find_backend(backend.as_ref().map(String::as_ref));
     main_loop::MainLoopState {
         librespot_connection: main_loop::LibreSpotConnection::new(connection, discovery_stream),
+        #[cfg(feature = "alsa_backend")]
         audio_setup: main_loop::AudioSetup {
             mixer,
             backend,
             audio_device: config.audio_device,
+        },
+        #[cfg(not(feature = "alsa_backend"))]
+        audio_setup: main_loop::AudioSetup {
+            mixer,
+            backend,
+            audio_device: None,
         },
         spotifyd_state: main_loop::SpotifydState {
             ctrl_c_stream: Box::new(ctrl_c(&handle).flatten_stream()),


### PR DESCRIPTION
As it was stated in #394, structs like `SharedConfigValues` or
`SpotifydConfig` contain fields like `mixer`, `control` and `device`
which only apply if `alsa-backend` feature is enabled.

Therefore, it would be nice if these fields were only documented when
the feature is enabled as well as used.

Closes #394