### PR TITLE
remove librespot's with-tremor feature flag in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tokio-io = "0.1"
 tokio-signal = "0.1"
 url = "1.7"
 xdg = "2.2"
-librespot = { version = "0.1.3", default-features = false, features = ["with-tremor"] }
+librespot = { version = "0.1.3", default-features = false }
 toml = "0.5.8"
 color-eyre = "0.5"
 


### PR DESCRIPTION
Fix issue #719 for FreeBSD ports
Tested on FreeBSD 12.1