### PR TITLE
Update Summary with correct link to MacOS docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,7 +6,7 @@
   - [Installing on a Raspberry Pi](./installation/Raspberry-Pi.md)
   - [Installing on Ubuntu (from source)](./installation/Ubuntu.md)
   - [Cross Compiling on Ubuntu](./installation/Cross-Compiling-on-Ubuntu.md)
-  - [Installing with Homebrew on macOS](./installatio/MacOS.md)
+  - [Installing with Homebrew on macOS](./installation/MacOS.md)
   - [Feature Flags](./Feature-flags.md)
 - [Configuration](./config/README.md)
   - [CLI options](./config/Cli.md)


### PR DESCRIPTION
I found the Document not found error. There was a typo error on 'installation' word. I just corrected that.