### PR TITLE
improve panic message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ fn main() -> Result<(), Report> {
 
     panic::set_hook(Box::new(|panic_info| {
         error!(
-            "Caught panic with message: {}",
+            "PANIC: Shutting down spotifyd. Error message: {}",
             match (
                 panic_info.payload().downcast_ref::<String>(),
                 panic_info.payload().downcast_ref::<&str>(),


### PR DESCRIPTION
The current error message might be hard to detect as such, as you can see in  #924. This PR aims to make it easier to figure out the actual reason for panicking.