### PR TITLE
Created cli-option log-path that when set overrides syslog

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -228,6 +228,10 @@ pub struct CliConfig {
     #[structopt(long, value_name = "string")]
     pub config_path: Option<PathBuf>,
 
+    /// Path to a logfile. If set, overrides syslog output
+    #[structopt(long, value_name = "string")]
+    pub log_path: Option<PathBuf>,
+
     /// If set, starts spotifyd without detaching
     #[structopt(long)]
     pub no_daemon: bool,


### PR DESCRIPTION
Progress on #654, added a cli option `--log-path` that override syslog as a target for logging.

Also made the no-syslog error message a little clearer.