### PR TITLE
Use librespot libraries instead of its binary crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,12 +171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,12 +391,6 @@ checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 dependencies = [
  "ppv-lite86",
 ]
-
-[[package]]
-name = "c_linked_list"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cc"
@@ -1111,28 +1099,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "get_if_addrs"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
-dependencies = [
- "c_linked_list",
- "get_if_addrs-sys",
- "libc",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "get_if_addrs-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
-dependencies = [
- "gcc",
- "libc",
-]
-
-[[package]]
 name = "gethostname"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,15 +1106,6 @@ checksum = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
 dependencies = [
  "libc",
  "winapi 0.3.8",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1210,12 +1167,6 @@ checksum = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "hex"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 
 [[package]]
 name = "hex"
@@ -1406,6 +1357,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28538916eb3f3976311f5dfbe67b5362d0add1293d0a9cad17debf86f8e3aa48"
+dependencies = [
+ "if-addrs-sys",
+ "libc",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "if-addrs-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de74b9dd780476e837e5eb5ab7c88b49ed304126e412030a0adba99c8efe79ea"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,14 +1503,14 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libmdns"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966e0f9cc15be41e9dbfcd74fd9c04cf69d3c0ec43fc56aa28f5e4da4e545c38"
+checksum = "5d8582c174736c53633bc482ac709b24527c018356c3dc6d8e25a788b06b394e"
 dependencies = [
  "byteorder",
  "futures 0.1.29",
- "get_if_addrs",
  "hostname",
+ "if-addrs",
  "log 0.4.8",
  "multimap",
  "net2",
@@ -1554,37 +1526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb11b06faf883500c1b625cf4453e6c7737e9df9c7ba01df3f84b22b083e4ac"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "librespot"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45566ef7dae275ff9186e7623dff6a41ec7093bcb22622288069cb7adcad7d40"
-dependencies = [
- "base64 0.10.1",
- "env_logger 0.6.2",
- "futures 0.1.29",
- "getopts",
- "hex 0.3.2",
- "hyper 0.11.27",
- "librespot-audio",
- "librespot-connect",
- "librespot-core",
- "librespot-metadata",
- "librespot-playback",
- "librespot-protocol",
- "log 0.4.8",
- "num-bigint 0.2.5",
- "protobuf",
- "rand 0.7.3",
- "rpassword",
- "sha-1 0.8.2",
- "tokio-core",
- "tokio-io",
- "tokio-process",
- "tokio-signal 0.2.7",
- "url 1.7.2",
 ]
 
 [[package]]
@@ -1847,22 +1788,10 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log 0.4.8",
- "miow 0.2.1",
+ "miow",
  "net2",
  "slab 0.4.2",
  "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio-named-pipes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
-dependencies = [
- "log 0.4.8",
- "mio",
- "miow 0.3.3",
- "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1889,20 +1818,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "miow"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
-dependencies = [
- "socket2",
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "multimap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 dependencies = [
  "serde",
 ]
@@ -2724,17 +2643,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rpassword"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34fa7bcae7fca3c8471e8417088bbc3ad9af8066b0ecf4f3c0d98a0d772716e"
-dependencies = [
- "kernel32-sys",
- "libc",
- "winapi 0.2.8",
-]
-
-[[package]]
 name = "rspotify"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3023,26 +2931,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
-name = "signal-hook"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9c17dd3ba2d36023a5c9472ecddeda07e27fd0b05436e8c1e0c8f178185652"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
-dependencies = [
- "arc-swap",
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,18 +2964,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
 
 [[package]]
-name = "socket2"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "redox_syscall",
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "sourcefile"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3107,10 +2983,13 @@ dependencies = [
  "fern",
  "futures 0.1.29",
  "gethostname",
- "hex 0.4.2",
+ "hex",
  "keyring",
  "libc",
- "librespot",
+ "librespot-audio",
+ "librespot-connect",
+ "librespot-core",
+ "librespot-playback",
  "log 0.4.8",
  "percent-encoding 2.1.0",
  "rspotify",
@@ -3120,7 +2999,7 @@ dependencies = [
  "syslog",
  "tokio-core",
  "tokio-io",
- "tokio-signal 0.1.5",
+ "tokio-signal",
  "toml",
  "url 1.7.2",
  "whoami",
@@ -3420,25 +3299,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-process"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbd6ef1b8cc2bd2c2b580d882774d443ebb1c6ceefe35ba9ea4ab586c89dbe8"
-dependencies = [
- "crossbeam-queue",
- "futures 0.1.29",
- "lazy_static",
- "libc",
- "log 0.4.8",
- "mio",
- "mio-named-pipes",
- "tokio-io",
- "tokio-reactor",
- "tokio-signal 0.2.7",
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "tokio-proto"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3496,23 +3356,6 @@ dependencies = [
  "mio-uds",
  "tokio-core",
  "tokio-io",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "tokio-signal"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6dc5276ea05ce379a16de90083ec80836440d5ef8a6a39545a3207373b8296"
-dependencies = [
- "futures 0.1.29",
- "libc",
- "mio",
- "mio-uds",
- "signal-hook",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
  "winapi 0.3.8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,10 @@ tokio-io = "0.1"
 tokio-signal = "0.1"
 url = "1.7"
 xdg = "2.2"
-librespot = { version = "0.1.5", default-features = false, features = ["with-tremor"] }
+librespot-audio = { version = "0.1.5", default-features = false, features = ["with-tremor"] }
+librespot-connect = "0.1.5"
+librespot-core = "0.1.5"
+librespot-playback = { version = "0.1.5", default-features = false }
 toml = "0.5.8"
 color-eyre = "0.5"
 
@@ -42,13 +45,13 @@ whoami = "0.9.0"
 env_logger = "0.7"
 
 [features]
-alsa_backend = ["librespot/alsa-backend", "alsa"]
+alsa_backend = ["librespot-playback/alsa-backend", "alsa"]
 dbus_keyring = ["keyring"]
 dbus_mpris = ["dbus", "dbus-tokio"]
 default = ["alsa_backend"]
-portaudio_backend = ["librespot/portaudio-backend"]
-pulseaudio_backend = ["librespot/pulseaudio-backend"]
-rodio_backend = ["librespot/rodio-backend"]
+portaudio_backend = ["librespot-playback/portaudio-backend"]
+pulseaudio_backend = ["librespot-playback/pulseaudio-backend"]
+rodio_backend = ["librespot-playback/rodio-backend"]
 
 [package.metadata.deb]
 depends = "$auto, systemd, pulseaudio"

--- a/src/alsa_mixer.rs
+++ b/src/alsa_mixer.rs
@@ -1,4 +1,4 @@
-use librespot::playback::mixer::{AudioFilter, Mixer, MixerConfig};
+use librespot_playback::mixer::{AudioFilter, Mixer, MixerConfig};
 use log::error;
 use std::error::Error;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,10 +5,10 @@ use crate::{
 };
 use color_eyre::Report;
 use gethostname::gethostname;
-use librespot::{
-    core::{cache::Cache, config::DeviceType as LSDeviceType, config::SessionConfig, version},
-    playback::config::{Bitrate as LSBitrate, PlayerConfig},
+use librespot_core::{
+    cache::Cache, config::DeviceType as LSDeviceType, config::SessionConfig, version,
 };
+use librespot_playback::config::{Bitrate as LSBitrate, PlayerConfig};
 use log::{error, info, warn};
 use serde::{de::Error, de::Unexpected, Deserialize, Deserializer};
 use sha1::{Digest, Sha1};

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -9,13 +9,11 @@ use dbus_tokio::{
     AConnection,
 };
 use futures::{sync::oneshot, Async, Future, Poll, Stream};
-use librespot::{
-    connect::spirc::Spirc,
-    core::{
-        keymaster::{get_token, Token as LibrespotToken},
-        mercury::MercuryError,
-        session::Session,
-    },
+use librespot_connect::spirc::Spirc;
+use librespot_core::{
+    keymaster::{get_token, Token as LibrespotToken},
+    mercury::MercuryError,
+    session::Session,
 };
 use log::{info, warn};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -2,22 +2,20 @@
 use crate::dbus_mpris::DbusServer;
 use crate::process::{spawn_program_on_event, Child};
 use futures::{self, Async, Future, Poll, Stream};
-use librespot::{
-    connect::{
-        discovery::DiscoveryStream,
-        spirc::{Spirc, SpircTask},
-    },
-    core::{
-        cache::Cache,
-        config::{ConnectConfig, DeviceType, SessionConfig, VolumeCtrl},
-        session::Session,
-    },
-    playback::{
-        audio_backend::Sink,
-        config::PlayerConfig,
-        mixer::Mixer,
-        player::{Player, PlayerEvent},
-    },
+use librespot_connect::{
+    discovery::DiscoveryStream,
+    spirc::{Spirc, SpircTask},
+};
+use librespot_core::{
+    cache::Cache,
+    config::{ConnectConfig, DeviceType, SessionConfig, VolumeCtrl},
+    session::Session,
+};
+use librespot_playback::{
+    audio_backend::Sink,
+    config::PlayerConfig,
+    mixer::Mixer,
+    player::{Player, PlayerEvent},
 };
 use log::error;
 use std::{io, rc::Rc};

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use librespot::playback::player::PlayerEvent;
+use librespot_playback::player::PlayerEvent;
 use log::info;
 use std::{
     collections::HashMap,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -4,18 +4,16 @@ use crate::{config, main_loop};
 use futures::{self, Future};
 #[cfg(feature = "dbus_keyring")]
 use keyring::Keyring;
-use librespot::{
-    connect::discovery::discovery,
-    core::{
-        authentication::get_credentials,
-        cache::Cache,
-        config::{ConnectConfig, DeviceType, VolumeCtrl},
-        session::Session,
-    },
-    playback::{
-        audio_backend::{Sink, BACKENDS},
-        mixer::{self, Mixer},
-    },
+use librespot_connect::discovery::discovery;
+use librespot_core::{
+    authentication::get_credentials,
+    cache::Cache,
+    config::{ConnectConfig, DeviceType, VolumeCtrl},
+    session::Session,
+};
+use librespot_playback::{
+    audio_backend::{Sink, BACKENDS},
+    mixer::{self, Mixer},
 };
 use log::{error, info};
 use std::str::FromStr;


### PR DESCRIPTION
librespot's main crate is just a reexport of its sub-modules: https://github.com/librespot-org/librespot/blob/v0.1.5/src/lib.rs#L4

The number of dependencies on spotifyd can be reduced by depending on librespot's sub-modules instead, this PR does that.

I didn't bump librespot's version to the [latest 0.2][0] since it depends on tokio 1 instead of tokio 0.1.

Note: this PR has the side effect of doing a `cargo update` on the librespot dep

[0]: https://github.com/librespot-org/librespot/releases/tag/v0.2.0