### PR TITLE
add configuration option for bus type

### DIFF
--- a/docs/src/config/File.md
+++ b/docs/src/config/File.md
@@ -29,10 +29,19 @@ password_cmd = "command_that_writes_password_to_stdout"
 # can't be used simultaneously.
 use_keyring = true
 
-# If set to true, `spotifyd` tries to bind to the session dbus
-# and expose MPRIS controls. When running headless, without a dbus session,
-# then set this to false to avoid binding errors
+# If set to true, `spotifyd` tries to bind to dbus (default is the session bus)
+# and expose MPRIS controls. When running headless, without the session bus,
+# you should set this to false, to avoid errors. If you still want to use MPRIS,
+# have a look at the `dbus_type` option.
 use_mpris = true
+
+# The bus to bind to with the MPRIS interface.
+# Possible values: "session", "system"
+# The system bus can be used if no graphical session is available
+# (e.g. on headless systems) but you still want to be able to use MPRIS.
+# NOTE: You might need to add appropriate policies to allow spotifyd to
+# own the name.
+dbus_type = "session"
 
 # The audio backend used to play music. To get
 # a list of possible backends, run `spotifyd --help`.

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1,3 +1,4 @@
+use crate::config::DBusType;
 #[cfg(feature = "dbus_mpris")]
 use crate::dbus_mpris::DbusServer;
 use crate::process::spawn_program_on_event;
@@ -81,6 +82,8 @@ pub(crate) struct MainLoop {
     pub(crate) device_type: DeviceType,
     #[cfg_attr(not(feature = "dbus_mpris"), allow(unused))]
     pub(crate) use_mpris: bool,
+    #[cfg_attr(not(feature = "dbus_mpris"), allow(unused))]
+    pub(crate) dbus_type: DBusType,
     pub(crate) credentials_provider: CredentialsProvider,
 }
 
@@ -156,6 +159,7 @@ impl MainLoop {
                     shared_spirc.clone(),
                     self.spotifyd_state.device_name.clone(),
                     rx,
+                    self.dbus_type,
                 ));
                 Some(tx)
             } else {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -139,6 +139,7 @@ pub(crate) fn initial_state(config: config::SpotifydConfig) -> main_loop::MainLo
         device_type,
         autoplay,
         use_mpris: config.use_mpris,
+        dbus_type: config.dbus_type,
     }
 }
 


### PR DESCRIPTION
This adds a new configuration option to configure which bus should be used by spotifyd. It addresses situations like #944 or one I personally found me in, where access to the MPRIS interface on headless systems would really help a lot.

Since I'm quite new to the codebase as well as the Rust ecosystem in general, I'm not sure if everything I changed / added was a good idea. Therefore, I'm always happy to take improvement proposals and adapt the PR accordingly. :grinning: