### PR TITLE
document zeroconf based authentication properly

### DIFF
--- a/docs/src/config/File.md
+++ b/docs/src/config/File.md
@@ -105,7 +105,7 @@ device_type = "speaker"
 
   Spotifyd is able to advertise itself on the network without credentials. To enable this, you must omit / comment any `username` / `username_cmd` or `password` / `password_cmd` in the configuration. Spotifyd will receive an authentication blob from Spotify when you choose it from the devices list.
 
-  > __Note:__ If you choose to go with this, it is also recommended to omit the `cache_path` option. Otherwise the first user to connect to the service will have its authentication blob cached by the service and nobody else will be able to connect to the service without clearing the cache.
+  > __Note:__ If you choose to go with this, it is also recommended to omit the `cache_path` and `cache_directory` options. Otherwise the first user to connect to the service will have its authentication blob cached by the service and nobody else will be able to connect to the service without clearing the cache.
 
   This way, a Spotifyd instance can also be made available to multiple users.
 

--- a/docs/src/config/File.md
+++ b/docs/src/config/File.md
@@ -105,6 +105,8 @@ device_type = "speaker"
 
   Spotifyd is able to advertise itself on the network without credentials. To enable this, you must omit / comment any `username` / `username_cmd` or `password` / `password_cmd` in the configuration. Spotifyd will receive an authentication blob from Spotify when you choose it from the devices list.
 
+  > __Note:__ If you choose to go with this, it is also recommended to omit the `cache_path` option. Otherwise the first user to connect to the service will have its authentication blob cached by the service and nobody else will be able to connect to the service without clearing the cache.
+
   This way, a Spotifyd instance can also be made available to multiple users.
 
   For more information, have a look at the [librespot documentation][librespot-docs].

--- a/docs/src/config/File.md
+++ b/docs/src/config/File.md
@@ -101,6 +101,14 @@ device_type = "speaker"
 
 ## Alternatives to storing your password in the config file <!-- omit in toc -->
 
+- use zeroconf authentication from Spotify Connect
+
+  Spotifyd is able to advertise itself on the network without credentials. To enable this, you must omit / comment any `username` / `username_cmd` or `password` / `password_cmd` in the configuration. Spotifyd will receive an authentication blob from Spotify when you choose it from the devices list.
+
+  This way, a Spotifyd instance can also be made available to multiple users.
+
+  For more information, have a look at the [librespot documentation][librespot-docs].
+
 - **`password_cmd`** config entry
 
   This feature allows you to provide a command that prints your password to `stdout`, which saves you from having to store your password in the config file directly. To use it, set the `password_cmd` config entry to the command you would like to use and remove the `password` config entry.
@@ -144,3 +152,4 @@ If either of these options is given, the shell `spotifyd` will use to run its co
 [playerctl-homepage]: https://github.com/altdesktop/playerctl
 [secret-storage-specification]: https://www.freedesktop.org/wiki/Specifications/secret-storage-spec/
 [sp-homepage]: https://gist.github.com/wandernauta/6800547
+[librespot-docs]: https://github.com/librespot-org/librespot/blob/master/docs/authentication.md#zeroconf-based-authentication


### PR DESCRIPTION
In order to be able to use zeroconf based authentication, it is currently necessary to omit everything related to username or password in the configuration. 

AFAICT, this is not really documented anywhere except for [this wiki entry](https://spotifyd.github.io/spotifyd/config/index.html), which does barely go into details about this. Maybe I just haven't looked in the right places for this, but several others (#938, #948) seem to have trouble finding anything as well.