### PR TITLE
Upgrade librespot to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,36 +69,14 @@ dependencies = [
 
 [[package]]
 name = "alsa"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6a5e4eb4879d7cb8d19161927fbf825f0d89761776359c9cf4f9c9c2f35c52"
-dependencies = [
- "alsa-sys 0.1.2",
- "bitflags 0.9.1",
- "libc",
- "nix 0.14.1",
-]
-
-[[package]]
-name = "alsa"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c4da790adcb2ce5e758c064b4f3ec17a30349f9961d3e5e6c9688b052a9e18"
 dependencies = [
- "alsa-sys 0.3.1",
- "bitflags 1.2.1",
+ "alsa-sys",
+ "bitflags",
  "libc",
- "nix 0.20.0",
-]
-
-[[package]]
-name = "alsa-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0edcbbf9ef68f15ae1b620f722180b82a98b6f0628d30baa6b8d2a5abc87d58"
-dependencies = [
- "libc",
- "pkg-config",
+ "nix",
 ]
 
 [[package]]
@@ -201,7 +179,7 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebd71393f1ec0509b553aa012b9b58e81dadbdff7130bd3b8cba576e69b32f75"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "cexpr",
  "cfg-if 0.1.10",
  "clang-sys",
@@ -213,12 +191,6 @@ dependencies = [
  "rustc-hash",
  "shlex",
 ]
-
-[[package]]
-name = "bitflags"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 
 [[package]]
 name = "bitflags"
@@ -377,7 +349,7 @@ checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags 1.2.1",
+ "bitflags",
  "strsim 0.8.0",
  "textwrap",
  "unicode-width",
@@ -390,7 +362,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -474,7 +446,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11894b20ebfe1ff903cbdc52259693389eea03b94918a2def2c30c3bf227ad88"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "coreaudio-sys",
 ]
 
@@ -493,7 +465,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8351ddf2aaa3c583fa388029f8b3d26f3c7035a20911fdd5f2e2ed7ab57dad25"
 dependencies = [
- "alsa 0.5.0",
+ "alsa",
  "core-foundation-sys 0.6.2",
  "coreaudio-rs",
  "jni",
@@ -503,7 +475,7 @@ dependencies = [
  "mach",
  "ndk",
  "ndk-glue",
- "nix 0.20.0",
+ "nix",
  "oboe",
  "parking_lot 0.11.1",
  "stdweb",
@@ -899,7 +871,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "fuchsia-zircon-sys",
 ]
 
@@ -1130,7 +1102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
 dependencies = [
  "base64 0.13.0",
- "bitflags 1.2.1",
+ "bitflags",
  "bytes 1.0.1",
  "headers-core",
  "http",
@@ -1591,7 +1563,7 @@ version = "2.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db951f37898e19a6785208e3a290261e0f1a8e086716be596aaad684882ca8e3"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "libc",
  "libpulse-sys",
  "num-derive",
@@ -1769,7 +1741,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ca3df986a7e1a43008717660803e159177e86a589d484a0fc01fccd7967ad6"
 dependencies = [
- "alsa 0.5.0",
+ "alsa",
  "byteorder",
  "cpal",
  "futures-executor",
@@ -2036,24 +2008,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
-dependencies = [
- "bitflags 1.2.1",
- "cc",
- "cfg-if 0.1.10",
- "libc",
- "void",
-]
-
-[[package]]
-name = "nix"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "cc",
  "cfg-if 1.0.0",
  "libc",
@@ -2276,7 +2235,7 @@ version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -2458,7 +2417,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb6b5eff96ccc9bf44d34c379ab03ae944426d83d1694345bdf8159d561d562"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "libc",
  "portaudio-sys",
 ]
@@ -2817,7 +2776,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -3046,7 +3005,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "core-foundation 0.7.0",
  "core-foundation-sys 0.7.0",
  "libc",
@@ -3059,7 +3018,7 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "core-foundation 0.9.1",
  "core-foundation-sys 0.8.2",
  "libc",
@@ -3257,7 +3216,7 @@ dependencies = [
 name = "spotifyd"
 version = "0.3.2"
 dependencies = [
- "alsa 0.3.0",
+ "alsa",
  "chrono",
  "color-eyre",
  "daemonize",
@@ -3893,7 +3852,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aba5e34f93dc7051dfad05b98a18e9156f27e7b431fe1d2398cb6061c0a1dba"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "chrono",
  "failure",
 ]
@@ -3909,12 +3868,6 @@ name = "version_check"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,12 +99,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
-
-[[package]]
 name = "async-trait"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,7 +740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 dependencies = [
  "atty",
- "humantime 1.3.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -759,21 +753,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime 1.3.0",
+ "humantime",
  "log",
  "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "atty",
- "humantime 2.1.0",
- "log",
  "termcolor",
 ]
 
@@ -1009,15 +991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,31 +1067,6 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "headers"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
-dependencies = [
- "base64 0.13.0",
- "bitflags",
- "bytes 1.0.1",
- "headers-core",
- "http",
- "mime",
- "sha-1",
- "time",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http",
-]
 
 [[package]]
 name = "heck"
@@ -1239,12 +1187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,21 +1232,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
-]
-
-[[package]]
-name = "hyper-proxy"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
-dependencies = [
- "bytes 1.0.1",
- "futures 0.3.15",
- "headers",
- "http",
- "hyper 0.14.5",
- "tokio 1.8.1",
- "tower-service",
 ]
 
 [[package]]
@@ -1363,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28538916eb3f3976311f5dfbe67b5362d0add1293d0a9cad17debf86f8e3aa48"
+checksum = "2273e421f7c4f0fc99e1934fe4776f59d8df2972f4199d703fc0da9f2a9f73de"
 dependencies = [
  "if-addrs-sys",
  "libc",
@@ -1541,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "libmdns"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98477a6781ae1d6a1c2aeabfd2e23353a75fe8eb7c2545f6ed282ac8f3e2fc53"
+checksum = "fac185a4d02e873c6d1ead59d674651f8ae5ec23ffe1637bee8de80665562a6a"
 dependencies = [
  "byteorder",
  "futures-util",
@@ -1603,32 +1530,6 @@ dependencies = [
  "num-traits",
  "pkg-config",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "librespot"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "450aa724dcc28a06c6f3a070e7f4b84c0800d9152bec3b012a11ff886986bd58"
-dependencies = [
- "base64 0.13.0",
- "env_logger 0.8.4",
- "futures-util",
- "getopts",
- "hex",
- "hyper 0.14.5",
- "librespot-audio",
- "librespot-connect",
- "librespot-core",
- "librespot-metadata",
- "librespot-playback",
- "librespot-protocol",
- "log",
- "rpassword",
- "sha-1",
- "thiserror",
- "tokio 1.8.1",
- "url 2.2.2",
 ]
 
 [[package]]
@@ -1696,8 +1597,6 @@ dependencies = [
  "hmac 0.11.0",
  "http",
  "httparse",
- "hyper 0.14.5",
- "hyper-proxy",
  "librespot-protocol",
  "log",
  "num-bigint 0.4.0",
@@ -1925,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 dependencies = [
  "serde",
 ]
@@ -2887,16 +2786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rpassword"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "rspotify"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3173,11 +3062,10 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
- "arc-swap",
  "libc",
 ]
 
@@ -3230,7 +3118,10 @@ dependencies = [
  "hex",
  "keyring",
  "libc",
- "librespot",
+ "librespot-audio",
+ "librespot-connect",
+ "librespot-core",
+ "librespot-playback",
  "log",
  "percent-encoding 2.1.0",
  "reqwest 0.11.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,55 +519,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils 0.7.0",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
-dependencies = [
- "autocfg 0.1.7",
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.0",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
-dependencies = [
- "crossbeam-utils 0.6.6",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 dependencies = [
- "cfg-if 0.1.10",
- "lazy_static",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
-dependencies = [
- "autocfg 0.1.7",
  "cfg-if 0.1.10",
  "lazy_static",
 ]
@@ -692,25 +648,35 @@ dependencies = [
 
 [[package]]
 name = "dbus"
-version = "0.6.5"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48b5f0f36f1eebe901b0e6bee369a77ed3396334bf3f09abd46454a576f71819"
+checksum = "c8862bb50aa3b2a2db5bfd2c875c73b3038aa931c411087e335ca8ca0ed430b9"
 dependencies = [
+ "futures-channel",
+ "futures-util",
  "libc",
  "libdbus-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "dbus-crossroads"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4581bbfd99f34e6864049adbe099e07c0d55c40760b23bb8e1e5d1c2ae68ca3"
+dependencies = [
+ "dbus 0.9.3",
 ]
 
 [[package]]
 name = "dbus-tokio"
-version = "0.2.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a58aa53eb3d63a9e0030471f6bb6a18e34553bdb6a7633149479f79fb907ad"
+checksum = "8b4083ad3ad374032aaacf18c4cce2c65c3ba5d4e576a037339a8b6cd0b4509c"
 dependencies = [
- "dbus 0.6.5",
- "futures 0.1.29",
- "log 0.3.9",
- "mio 0.6.23",
- "tokio-core",
+ "dbus 0.9.3",
+ "libc",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -809,7 +775,7 @@ checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 dependencies = [
  "atty",
  "humantime 1.3.0",
- "log 0.4.8",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -822,7 +788,7 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
  "humantime 1.3.0",
- "log 0.4.8",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -835,7 +801,7 @@ checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
  "humantime 2.1.0",
- "log 0.4.8",
+ "log",
  "termcolor",
 ]
 
@@ -886,7 +852,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065"
 dependencies = [
- "log 0.4.8",
+ "log",
  "syslog",
 ]
 
@@ -1126,7 +1092,7 @@ dependencies = [
  "futures-util",
  "http",
  "indexmap",
- "log 0.4.8",
+ "log",
  "slab",
  "tokio 0.2.25",
  "tokio-util 0.2.0",
@@ -1321,7 +1287,7 @@ dependencies = [
  "http-body 0.3.1",
  "httparse",
  "itoa",
- "log 0.4.8",
+ "log",
  "net2",
  "pin-project 0.4.8",
  "time",
@@ -1508,7 +1474,7 @@ dependencies = [
  "cesu8",
  "combine",
  "jni-sys",
- "log 0.4.8",
+ "log",
  "thiserror",
  "walkdir",
 ]
@@ -1611,7 +1577,7 @@ dependencies = [
  "futures-util",
  "hostname",
  "if-addrs",
- "log 0.4.8",
+ "log",
  "multimap",
  "rand 0.8.4",
  "socket2",
@@ -1685,7 +1651,7 @@ dependencies = [
  "librespot-metadata",
  "librespot-playback",
  "librespot-protocol",
- "log 0.4.8",
+ "log",
  "rpassword",
  "sha-1",
  "thiserror",
@@ -1707,7 +1673,7 @@ dependencies = [
  "lewton",
  "librespot-core",
  "librespot-tremor",
- "log 0.4.8",
+ "log",
  "ogg",
  "tempfile",
  "tokio 1.8.1",
@@ -1731,7 +1697,7 @@ dependencies = [
  "librespot-core",
  "librespot-playback",
  "librespot-protocol",
- "log 0.4.8",
+ "log",
  "protobuf",
  "rand 0.8.4",
  "serde",
@@ -1761,7 +1727,7 @@ dependencies = [
  "hyper 0.14.5",
  "hyper-proxy",
  "librespot-protocol",
- "log 0.4.8",
+ "log",
  "num-bigint 0.4.0",
  "num-integer",
  "num-traits",
@@ -1793,7 +1759,7 @@ dependencies = [
  "byteorder",
  "librespot-core",
  "librespot-protocol",
- "log 0.4.8",
+ "log",
  "protobuf",
 ]
 
@@ -1813,7 +1779,7 @@ dependencies = [
  "librespot-audio",
  "librespot-core",
  "librespot-metadata",
- "log 0.4.8",
+ "log",
  "portaudio-rs",
  "rodio",
  "shell-words",
@@ -1866,15 +1832,6 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.8",
-]
-
-[[package]]
-name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
@@ -1916,15 +1873,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
 
 [[package]]
-name = "memoffset"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,7 +1910,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.8",
+ "log",
  "miow 0.2.2",
  "net2",
  "slab",
@@ -1976,21 +1924,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
- "log 0.4.8",
+ "log",
  "miow 0.3.7",
  "ntapi",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
-dependencies = [
- "iovec",
- "libc",
- "mio 0.6.23",
 ]
 
 [[package]]
@@ -2031,7 +1968,7 @@ checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.8",
+ "log",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -2061,7 +1998,7 @@ checksum = "c5caf0c24d51ac1c905c27d4eda4fa0635bbe0de596b8f79235e0b17a4d29385"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.8",
+ "log",
  "ndk",
  "ndk-macro",
  "ndk-sys",
@@ -2927,7 +2864,7 @@ dependencies = [
  "hyper-tls 0.4.1",
  "js-sys",
  "lazy_static",
- "log 0.4.8",
+ "log",
  "mime",
  "mime_guess",
  "native-tls",
@@ -2965,7 +2902,7 @@ dependencies = [
  "ipnet",
  "js-sys",
  "lazy_static",
- "log 0.4.8",
+ "log",
  "mime",
  "native-tls",
  "percent-encoding 2.1.0",
@@ -3014,7 +2951,7 @@ dependencies = [
  "failure",
  "itertools",
  "lazy_static",
- "log 0.4.8",
+ "log",
  "percent-encoding 1.0.1",
  "rand 0.6.5",
  "random",
@@ -3080,12 +3017,6 @@ dependencies = [
  "lazy_static",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 
 [[package]]
 name = "scopeguard"
@@ -3330,7 +3261,8 @@ dependencies = [
  "chrono",
  "color-eyre",
  "daemonize",
- "dbus 0.6.5",
+ "dbus 0.9.3",
+ "dbus-crossroads",
  "dbus-tokio",
  "env_logger 0.7.1",
  "fern",
@@ -3340,7 +3272,7 @@ dependencies = [
  "keyring",
  "libc",
  "librespot",
- "log 0.4.8",
+ "log",
  "percent-encoding 2.1.0",
  "reqwest 0.11.4",
  "rspotify",
@@ -3465,7 +3397,7 @@ checksum = "a0641142b4081d3d44beffa4eefd7346a228cdf91ed70186db2ca2cef762d327"
 dependencies = [
  "error-chain",
  "libc",
- "log 0.4.8",
+ "log",
  "time",
 ]
 
@@ -3558,30 +3490,6 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "mio 0.6.23",
- "num_cpus",
- "tokio-codec",
- "tokio-current-thread",
- "tokio-executor",
- "tokio-fs",
- "tokio-io",
- "tokio-reactor",
- "tokio-sync",
- "tokio-tcp",
- "tokio-threadpool",
- "tokio-timer",
- "tokio-udp",
- "tokio-uds",
-]
-
-[[package]]
-name = "tokio"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
@@ -3618,17 +3526,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-codec"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "tokio-io",
-]
-
-[[package]]
 name = "tokio-compat"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3660,25 +3557,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-core"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "iovec",
- "log 0.4.8",
- "mio 0.6.23",
- "scoped-tls",
- "tokio 0.1.22",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
- "tokio-timer",
-]
-
-[[package]]
 name = "tokio-current-thread"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3694,19 +3572,8 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6df436c42b0c3330a82d855d2ef017cd793090ad550a6bc2184f4b933532ab"
 dependencies = [
- "crossbeam-utils 0.6.6",
+ "crossbeam-utils",
  "futures 0.1.29",
-]
-
-[[package]]
-name = "tokio-fs"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
-dependencies = [
- "futures 0.1.29",
- "tokio-io",
- "tokio-threadpool",
 ]
 
 [[package]]
@@ -3717,7 +3584,7 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
- "log 0.4.8",
+ "log",
 ]
 
 [[package]]
@@ -3747,10 +3614,10 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6732fe6b53c8d11178dcb77ac6d9682af27fc6d4cb87789449152e5377377146"
 dependencies = [
- "crossbeam-utils 0.6.6",
+ "crossbeam-utils",
  "futures 0.1.29",
  "lazy_static",
- "log 0.4.8",
+ "log",
  "mio 0.6.23",
  "num_cpus",
  "parking_lot 0.9.0",
@@ -3796,43 +3663,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tcp"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "iovec",
- "mio 0.6.23",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-threadpool"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c32ffea4827978e9aa392d2f743d973c1dfa3730a2ed3f22ce1e6984da848c"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-queue",
- "crossbeam-utils 0.6.6",
- "futures 0.1.29",
- "lazy_static",
- "log 0.4.8",
- "num_cpus",
- "slab",
- "tokio-executor",
-]
-
-[[package]]
 name = "tokio-timer"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1739638e364e558128461fc1ad84d997702c8e31c2e6b18fb99842268199e827"
 dependencies = [
- "crossbeam-utils 0.6.6",
+ "crossbeam-utils",
  "futures 0.1.29",
  "slab",
  "tokio-executor",
@@ -3849,39 +3685,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-udp"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02298505547f73e60f568359ef0d016d5acd6e830ab9bc7c4a5b3403440121b"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "log 0.4.8",
- "mio 0.6.23",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-uds"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "iovec",
- "libc",
- "log 0.4.8",
- "mio 0.6.23",
- "mio-uds",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3890,7 +3693,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures-core",
  "futures-sink",
- "log 0.4.8",
+ "log",
  "pin-project-lite 0.1.4",
  "tokio 0.2.25",
 ]
@@ -3904,7 +3707,7 @@ dependencies = [
  "bytes 1.0.1",
  "futures-core",
  "futures-sink",
- "log 0.4.8",
+ "log",
  "pin-project-lite 0.2.4",
  "tokio 1.8.1",
 ]
@@ -4130,7 +3933,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.8",
+ "log",
  "try-lock",
 ]
 
@@ -4166,7 +3969,7 @@ checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.8",
+ "log",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
  "syn 1.0.73",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,47 +17,25 @@ checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aes"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
-dependencies = [
- "aes-soft 0.3.3",
- "aesni 0.6.0",
- "block-cipher-trait",
-]
-
-[[package]]
-name = "aes"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
 dependencies = [
- "aes-soft 0.6.4",
- "aesni 0.10.0",
+ "aes-soft",
+ "aesni",
  "cipher",
 ]
 
 [[package]]
 name = "aes-ctr"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e5b0458ea3beae0d1d8c0f3946564f8e10f90646cf78c06b4351052058d1ee"
+checksum = "7729c3cde54d67063be556aeac75a81330d802f0259500ca40cb52967f975763"
 dependencies = [
- "aes-soft 0.3.3",
- "aesni 0.6.0",
+ "aes-soft",
+ "aesni",
+ "cipher",
  "ctr",
- "stream-cipher",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
-dependencies = [
- "block-cipher-trait",
- "byteorder",
- "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -67,18 +45,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
 dependencies = [
  "cipher",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aesni"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
-dependencies = [
- "block-cipher-trait",
- "opaque-debug 0.2.3",
- "stream-cipher",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -88,7 +55,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
  "cipher",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -101,39 +68,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "alga"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658f9468113d34781f6ca9d014d174c74b73de870f1e0e3ad32079bbab253b19"
-dependencies = [
- "approx",
- "libm",
- "num-complex 0.2.4",
- "num-traits",
-]
-
-[[package]]
-name = "alsa"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a0d4ebc8b23041c5de9bc9aee13b4bad844a589479701f31a5934cfe4aeb32"
-dependencies = [
- "alsa-sys",
- "bitflags 0.9.1",
- "libc",
- "nix 0.9.0",
-]
-
-[[package]]
 name = "alsa"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6a5e4eb4879d7cb8d19161927fbf825f0d89761776359c9cf4f9c9c2f35c52"
 dependencies = [
- "alsa-sys",
+ "alsa-sys 0.1.2",
  "bitflags 0.9.1",
  "libc",
  "nix 0.14.1",
+]
+
+[[package]]
+name = "alsa"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c4da790adcb2ce5e758c064b4f3ec17a30349f9961d3e5e6c9688b052a9e18"
+dependencies = [
+ "alsa-sys 0.3.1",
+ "bitflags 1.2.1",
+ "libc",
+ "nix 0.20.0",
 ]
 
 [[package]]
@@ -147,27 +102,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "anyhow"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
-
-[[package]]
-name = "approx"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
-dependencies = [
- "num-traits",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -177,6 +127,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 
 [[package]]
+name = "async-trait"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,7 +145,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -215,16 +176,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
-]
-
-[[package]]
-name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
@@ -239,6 +190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bindgen"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,27 +207,12 @@ dependencies = [
  "clang-sys",
  "lazy_static",
  "peeking_take_while",
- "proc-macro2 1.0.19",
- "quote 1.0.2",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
  "regex",
  "rustc-hash",
  "shlex",
 ]
-
-[[package]]
-name = "bit-set"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 
 [[package]]
 name = "bitflags"
@@ -286,42 +228,11 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding 0.1.5",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.3",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.4",
-]
-
-[[package]]
-name = "block-cipher-trait"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
-dependencies = [
- "generic-array 0.12.3",
-]
-
-[[package]]
-name = "block-modes"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31aa8410095e39fdb732909fb5730a48d5bd7c2e3cd76bd1b07b3dbea130c529"
-dependencies = [
- "block-cipher-trait",
- "block-padding 0.1.5",
+ "generic-array",
 ]
 
 [[package]]
@@ -330,17 +241,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a0e8073e8baa88212fb5823574c02ebccb395136ba9a164ab89379ec6072f0"
 dependencies = [
- "block-padding 0.2.1",
+ "block-padding",
  "cipher",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
 ]
 
 [[package]]
@@ -362,16 +264,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
 
 [[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
-
-[[package]]
 name = "byteorder"
-version = "1.3.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -385,9 +281,15 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "c2-chacha"
@@ -399,16 +301,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "c_linked_list"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
-
-[[package]]
 name = "cc"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+dependencies = [
+ "jobserver",
+]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -450,7 +355,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -516,13 +421,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.6.4"
+name = "combine"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
+checksum = "a2d47c1b11006b87e492b53b313bb699ce60e16613c4dddaa91f8f7c220ab2fa"
 dependencies = [
- "core-foundation-sys 0.6.2",
- "libc",
+ "bytes 1.0.1",
+ "memchr",
 ]
 
 [[package]]
@@ -536,11 +441,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.5.1"
+name = "core-foundation"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
+ "core-foundation-sys 0.8.2",
  "libc",
 ]
 
@@ -557,10 +463,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
-name = "coreaudio-rs"
-version = "0.9.1"
+name = "core-foundation-sys"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f229761965dad3e9b11081668a6ea00f1def7aa46062321b5ec245b834f6e491"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
+name = "coreaudio-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11894b20ebfe1ff903cbdc52259693389eea03b94918a2def2c30c3bf227ad88"
 dependencies = [
  "bitflags 1.2.1",
  "coreaudio-sys",
@@ -577,17 +489,27 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.8.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58ae1ed6536b1b233f5e3aeb6997a046ddb4d05e3f61701b58a92eb254a829e"
+checksum = "8351ddf2aaa3c583fa388029f8b3d26f3c7035a20911fdd5f2e2ed7ab57dad25"
 dependencies = [
- "alsa-sys",
- "core-foundation-sys 0.5.1",
+ "alsa 0.5.0",
+ "core-foundation-sys 0.6.2",
  "coreaudio-rs",
+ "jni",
+ "js-sys",
  "lazy_static",
  "libc",
+ "mach",
+ "ndk",
+ "ndk-glue",
+ "nix 0.20.0",
+ "oboe",
+ "parking_lot 0.11.1",
  "stdweb",
- "winapi 0.3.8",
+ "thiserror",
+ "web-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -652,32 +574,31 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-dependencies = [
- "generic-array 0.12.3",
- "subtle 1.0.0",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.0",
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
 name = "ctr"
-version = "0.3.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022cd691704491df67d25d006fe8eca083098253c4d43516c2206479c58c6736"
+checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
 dependencies = [
- "block-cipher-trait",
- "stream-cipher",
+ "cipher",
 ]
 
 [[package]]
@@ -696,8 +617,18 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.9.0",
+ "darling_macro 0.9.0",
+]
+
+[[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core 0.10.2",
+ "darling_macro 0.10.2",
 ]
 
 [[package]]
@@ -715,14 +646,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "strsim 0.9.3",
+ "syn 1.0.73",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
 dependencies = [
- "darling_core",
+ "darling_core 0.9.0",
  "quote 0.6.13",
  "syn 0.15.44",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core 0.10.2",
+ "quote 1.0.9",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -753,7 +709,7 @@ dependencies = [
  "dbus 0.6.5",
  "futures 0.1.29",
  "log 0.3.9",
- "mio",
+ "mio 0.6.23",
  "tokio-core",
 ]
 
@@ -769,12 +725,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ac53fa6a3cda160df823a9346442525dcaf1e171999a1cf23e67067e4fd64d4"
 dependencies = [
- "darling",
+ "darling 0.9.0",
  "derive_builder_core",
  "proc-macro2 0.4.30",
  "quote 0.6.13",
@@ -787,19 +754,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0288a23da9333c246bb18c143426074a6ae96747995c5819d2947b64cd942b37"
 dependencies = [
- "darling",
+ "darling 0.9.0",
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
-]
-
-[[package]]
-name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -808,7 +766,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -850,7 +808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
  "log 0.4.8",
  "regex",
  "termcolor",
@@ -863,9 +821,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
  "log 0.4.8",
  "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime 2.1.0",
+ "log 0.4.8",
  "termcolor",
 ]
 
@@ -876,15 +846,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 dependencies = [
  "backtrace",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
-dependencies = [
- "version_check 0.1.5",
 ]
 
 [[package]]
@@ -913,17 +874,11 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.2",
- "syn 1.0.39",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
  "synstructure",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fern"
@@ -957,6 +912,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding 2.1.0",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,9 +951,9 @@ checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures"
-version = "0.3.4"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1001,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.4"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1011,25 +976,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.4"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
-
-[[package]]
-name = "futures-cpupool"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-dependencies = [
- "futures 0.1.29",
- "num_cpus",
-]
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.4"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1038,40 +993,43 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.4"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.4"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg 1.0.0",
  "proc-macro-hack",
- "proc-macro2 1.0.19",
- "quote 1.0.2",
- "syn 1.0.39",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.4"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.4"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-util"
-version = "0.3.4"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg 1.0.0",
+ "futures 0.1.29",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1079,10 +1037,11 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
+ "pin-project-lite 0.2.4",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
- "slab 0.4.2",
+ "slab",
 ]
 
 [[package]]
@@ -1090,15 +1049,6 @@ name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
-name = "generic-array"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "generic-array"
@@ -1111,35 +1061,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "get_if_addrs"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
-dependencies = [
- "c_linked_list",
- "get_if_addrs-sys",
- "libc",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "get_if_addrs-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
-dependencies = [
- "gcc",
- "libc",
-]
-
-[[package]]
 name = "gethostname"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1159,7 +1087,18 @@ checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1180,7 +1119,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1188,9 +1127,59 @@ dependencies = [
  "http",
  "indexmap",
  "log 0.4.8",
- "slab 0.4.2",
- "tokio 0.2.11",
- "tokio-util",
+ "slab",
+ "tokio 0.2.25",
+ "tokio-util 0.2.0",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 1.8.1",
+ "tokio-util 0.6.7",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "headers"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
+dependencies = [
+ "base64 0.13.0",
+ "bitflags 1.2.1",
+ "bytes 1.0.1",
+ "headers-core",
+ "http",
+ "mime",
+ "sha-1",
+ "time",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -1213,12 +1202,6 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
-
-[[package]]
-name = "hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
@@ -1229,18 +1212,8 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
 dependencies = [
- "digest 0.9.0",
+ "digest",
  "hmac 0.10.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
-dependencies = [
- "crypto-mac 0.7.0",
- "digest 0.8.1",
 ]
 
 [[package]]
@@ -1250,7 +1223,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac 0.10.0",
- "digest 0.9.0",
+ "digest",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac 0.11.0",
+ "digest",
 ]
 
 [[package]]
@@ -1261,7 +1244,7 @@ checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
  "libc",
  "match_cfg",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1270,7 +1253,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -1281,8 +1264,19 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.6",
  "http",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+dependencies = [
+ "bytes 1.0.1",
+ "http",
+ "pin-project-lite 0.2.4",
 ]
 
 [[package]]
@@ -1290,6 +1284,12 @@ name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+
+[[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
@@ -1301,31 +1301,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper"
-version = "0.11.27"
+name = "humantime"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a590ca09d341e94cddf8e5af0bbccde205d5fbc2fa3c09dd67c7f85cea59d7"
-dependencies = [
- "base64 0.9.3",
- "bytes 0.4.12",
- "futures 0.1.29",
- "futures-cpupool",
- "httparse",
- "iovec",
- "language-tags",
- "log 0.4.8",
- "mime",
- "net2",
- "percent-encoding 1.0.1",
- "relay",
- "time",
- "tokio-core",
- "tokio-io",
- "tokio-proto",
- "tokio-service",
- "unicase",
- "want 0.0.4",
-]
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1333,35 +1312,61 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa1c527bbc634be72aa7ba31e4e4def9bbb020f5416916279b7c705cd838893e"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.2.1",
  "http",
- "http-body",
+ "http-body 0.3.1",
  "httparse",
  "itoa",
  "log 0.4.8",
  "net2",
- "pin-project",
+ "pin-project 0.4.8",
  "time",
- "tokio 0.2.11",
+ "tokio 0.2.25",
  "tower-service",
- "want 0.3.0",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.3",
+ "http",
+ "http-body 0.4.2",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.7",
+ "socket2",
+ "tokio 1.8.1",
+ "tower-service",
+ "tracing",
+ "want",
 ]
 
 [[package]]
 name = "hyper-proxy"
-version = "0.4.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f0925de2747e481e6e477dd212c25e8f745567f02f6182e04d27b97c3fbece"
+checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
 dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "hyper 0.11.27",
- "tokio-core",
- "tokio-io",
+ "bytes 1.0.1",
+ "futures 0.3.15",
+ "headers",
+ "http",
+ "hyper 0.14.5",
+ "tokio 1.8.1",
+ "tower-service",
 ]
 
 [[package]]
@@ -1370,11 +1375,24 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.6",
  "hyper 0.13.2",
  "native-tls",
- "tokio 0.2.11",
+ "tokio 0.2.25",
  "tokio-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.0.1",
+ "hyper 0.14.5",
+ "native-tls",
+ "tokio 1.8.1",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1406,6 +1424,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28538916eb3f3976311f5dfbe67b5362d0add1293d0a9cad17debf86f8e3aa48"
+dependencies = [
+ "if-addrs-sys",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "if-addrs-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de74b9dd780476e837e5eb5ab7c88b49ed304126e412030a0adba99c8efe79ea"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,11 +1452,21 @@ checksum = "f4d5eb2e114fec2b7fe0fadc22888ad2658789bb7acac4dbee9cf8389f971ec8"
 
 [[package]]
 name = "indexmap"
-version = "1.3.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 1.0.0",
+ "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1428,6 +1477,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -1445,10 +1500,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 
 [[package]]
-name = "js-sys"
-version = "0.3.35"
+name = "jni"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
+checksum = "24967112a1e4301ca5342ea339763613a37592b8a6ce6cf2e4494537c7a42faf"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log 0.4.8",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1472,14 +1556,8 @@ dependencies = [
  "byteorder",
  "secret-service",
  "security-framework 0.4.4",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
-
-[[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
@@ -1489,20 +1567,20 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lewton"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d542c1a317036c45c2aa1cf10cc9d403ca91eb2d333ef1a4917e5cb10628bd0"
+checksum = "777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030"
 dependencies = [
  "byteorder",
  "ogg",
- "smallvec 0.6.13",
+ "tinyvec",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.82"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "libdbus-sys"
@@ -1520,54 +1598,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
  "cc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
-name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
-
-[[package]]
 name = "libmdns"
-version = "0.2.6"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966e0f9cc15be41e9dbfcd74fd9c04cf69d3c0ec43fc56aa28f5e4da4e545c38"
+checksum = "98477a6781ae1d6a1c2aeabfd2e23353a75fe8eb7c2545f6ed282ac8f3e2fc53"
 dependencies = [
  "byteorder",
- "futures 0.1.29",
- "get_if_addrs",
+ "futures-util",
  "hostname",
+ "if-addrs",
  "log 0.4.8",
  "multimap",
- "net2",
- "quick-error",
- "rand 0.7.3",
- "tokio-core",
+ "rand 0.8.4",
+ "socket2",
+ "thiserror",
+ "tokio 1.8.1",
+]
+
+[[package]]
+name = "libpulse-binding"
+version = "2.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db951f37898e19a6785208e3a290261e0f1a8e086716be596aaad684882ca8e3"
+dependencies = [
+ "bitflags 1.2.1",
+ "libc",
+ "libpulse-sys",
+ "num-derive",
+ "num-traits",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "libpulse-simple-binding"
+version = "2.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a574975292db859087c3957b9182f7d53278553f06bddaa2099c90e4ac3a0ee0"
+dependencies = [
+ "libpulse-binding",
+ "libpulse-simple-sys",
+ "libpulse-sys",
+]
+
+[[package]]
+name = "libpulse-simple-sys"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "468cf582b7b022c0d1b266fefc7fc8fa7b1ddcb61214224f2f105c95a9c2d5c1"
+dependencies = [
+ "libpulse-sys",
+ "pkg-config",
 ]
 
 [[package]]
 name = "libpulse-sys"
-version = "0.0.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb11b06faf883500c1b625cf4453e6c7737e9df9c7ba01df3f84b22b083e4ac"
+checksum = "cf17e9832643c4f320c42b7d78b2c0510f45aa5e823af094413b94e45076ba82"
 dependencies = [
  "libc",
+ "num-derive",
+ "num-traits",
+ "pkg-config",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "librespot"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45566ef7dae275ff9186e7623dff6a41ec7093bcb22622288069cb7adcad7d40"
+checksum = "450aa724dcc28a06c6f3a070e7f4b84c0800d9152bec3b012a11ff886986bd58"
 dependencies = [
- "base64 0.10.1",
- "env_logger 0.6.2",
- "futures 0.1.29",
+ "base64 0.13.0",
+ "env_logger 0.8.4",
+ "futures-util",
  "getopts",
- "hex 0.3.2",
- "hyper 0.11.27",
+ "hex",
+ "hyper 0.14.5",
  "librespot-audio",
  "librespot-connect",
  "librespot-core",
@@ -1575,131 +1686,130 @@ dependencies = [
  "librespot-playback",
  "librespot-protocol",
  "log 0.4.8",
- "num-bigint 0.2.5",
- "protobuf",
- "rand 0.7.3",
  "rpassword",
- "sha-1 0.8.2",
- "tokio-core",
- "tokio-io",
- "tokio-process",
- "tokio-signal 0.2.7",
- "url 1.7.2",
+ "sha-1",
+ "thiserror",
+ "tokio 1.8.1",
+ "url 2.2.2",
 ]
 
 [[package]]
 name = "librespot-audio"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb02446a27d32de72697882e16de414f4605cf7769911356ce5d112b0ece4df7"
+checksum = "fa0e89d3e106d80600537eba02c17ea6dd8b3de3f46c99952b813b6f6d6445c0"
 dependencies = [
  "aes-ctr",
- "bit-set",
  "byteorder",
- "bytes 0.4.12",
- "futures 0.1.29",
+ "bytes 1.0.1",
+ "cfg-if 1.0.0",
+ "futures-util",
  "lewton",
  "librespot-core",
  "librespot-tremor",
  "log 0.4.8",
- "num-bigint 0.2.5",
- "num-traits",
+ "ogg",
  "tempfile",
+ "tokio 1.8.1",
+ "zerocopy",
 ]
 
 [[package]]
 name = "librespot-connect"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a31e1588d341dd6fff14f1e28bbaaccb37a27b64d86f1c08709e19955ed424"
+checksum = "69425fd6c8d74779f1ec86b16e6b3114df50c8a0d94db5a5601ef634bfb5e288"
 dependencies = [
  "aes-ctr",
- "base64 0.10.1",
- "block-modes 0.3.3",
- "futures 0.1.29",
- "hmac 0.7.1",
- "hyper 0.11.27",
+ "base64 0.13.0",
+ "form_urlencoded",
+ "futures-core",
+ "futures-util",
+ "hmac 0.11.0",
+ "hyper 0.14.5",
  "libmdns",
  "librespot-core",
  "librespot-playback",
  "librespot-protocol",
  "log 0.4.8",
- "num-bigint 0.2.5",
  "protobuf",
- "rand 0.7.3",
+ "rand 0.8.4",
  "serde",
- "serde_derive",
  "serde_json",
- "sha-1 0.8.2",
- "tokio-core",
- "url 1.7.2",
+ "sha-1",
+ "tokio 1.8.1",
+ "tokio-stream",
+ "url 2.2.2",
 ]
 
 [[package]]
 name = "librespot-core"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc85fffbdced25e79efdff8211b3af61595d027e0fc55b4b62478f96330dfd9b"
+checksum = "df3e70dce131f5531c982ca133f04fd1d1dd4208de27291dcd9ab6841c963248"
 dependencies = [
- "aes 0.3.2",
- "base64 0.10.1",
+ "aes",
+ "base64 0.13.0",
  "byteorder",
- "bytes 0.4.12",
- "error-chain 0.12.1",
- "futures 0.1.29",
- "hmac 0.7.1",
+ "bytes 1.0.1",
+ "form_urlencoded",
+ "futures-core",
+ "futures-util",
+ "hmac 0.11.0",
+ "http",
  "httparse",
- "hyper 0.11.27",
+ "hyper 0.14.5",
  "hyper-proxy",
- "lazy_static",
  "librespot-protocol",
  "log 0.4.8",
- "num-bigint 0.2.5",
+ "num-bigint 0.4.0",
  "num-integer",
  "num-traits",
+ "once_cell",
  "pbkdf2",
+ "priority-queue",
  "protobuf",
- "rand 0.7.3",
+ "rand 0.8.4",
  "serde",
- "serde_derive",
  "serde_json",
- "sha-1 0.8.2",
+ "sha-1",
  "shannon",
- "tokio-codec",
- "tokio-core",
- "tokio-io",
- "url 1.7.2",
+ "thiserror",
+ "tokio 1.8.1",
+ "tokio-stream",
+ "tokio-util 0.6.7",
+ "url 2.2.2",
  "uuid",
  "vergen",
 ]
 
 [[package]]
 name = "librespot-metadata"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6a8ad310413465b423b03dc57c411ae7a48a2aead6bfdbbb25af6217725d6f"
+checksum = "84157ce5d901dbdcaef17ed305deba5d87171725347673a1b632a334d910af47"
 dependencies = [
+ "async-trait",
  "byteorder",
- "futures 0.1.29",
  "librespot-core",
  "librespot-protocol",
- "linear-map",
  "log 0.4.8",
  "protobuf",
 ]
 
 [[package]]
 name = "librespot-playback"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1beba1febc648377c6207001c8ac7b99a974a2e001276a167f7aaa52c588fb7"
+checksum = "59ca3df986a7e1a43008717660803e159177e86a589d484a0fc01fccd7967ad6"
 dependencies = [
- "alsa 0.2.2",
+ "alsa 0.5.0",
  "byteorder",
  "cpal",
- "futures 0.1.29",
- "libc",
- "libpulse-sys",
+ "futures-executor",
+ "futures-util",
+ "libpulse-binding",
+ "libpulse-simple-binding",
  "librespot-audio",
  "librespot-core",
  "librespot-metadata",
@@ -1707,13 +1817,16 @@ dependencies = [
  "portaudio-rs",
  "rodio",
  "shell-words",
+ "thiserror",
+ "tokio 1.8.1",
+ "zerocopy",
 ]
 
 [[package]]
 name = "librespot-protocol"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac28eaad048e869fb9cd3e8c66485561ac540b85d1e4d30af0f2022144e3134"
+checksum = "1c753be4c3bd0f02b30c00d5d8547f16d557654cb737e70505aec6aa9990435d"
 dependencies = [
  "glob",
  "protobuf",
@@ -1734,16 +1847,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "linear-map"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfae20f6b19ad527b550c223fddc3077a547fc70cda94b9b566575423fd303ee"
-
-[[package]]
 name = "lock_api"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
 ]
@@ -1767,6 +1883,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,15 +1902,6 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-
-[[package]]
-name = "matrixmultiply"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f7ec66360130972f34830bfad9ef05c6610a43938a467bcc9ab9369ab3478f"
-dependencies = [
- "rawpointer",
-]
 
 [[package]]
 name = "maybe-uninit"
@@ -1836,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.21"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -1847,22 +1963,23 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log 0.4.8",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
- "slab 0.4.2",
+ "slab",
  "winapi 0.2.8",
 ]
 
 [[package]]
-name = "mio-named-pipes"
-version = "0.1.6"
+name = "mio"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
+ "libc",
  "log 0.4.8",
- "mio",
- "miow 0.3.3",
- "winapi 0.3.8",
+ "miow 0.3.7",
+ "ntapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1873,14 +1990,14 @@ checksum = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 dependencies = [
  "iovec",
  "libc",
- "mio",
+ "mio 0.6.23",
 ]
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -1890,12 +2007,11 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1908,27 +2024,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "nalgebra"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa9fddbc34c8c35dd2108515587b8ce0cab396f17977b8c738568e4edb521a2"
-dependencies = [
- "alga",
- "approx",
- "generic-array 0.12.3",
- "matrixmultiply",
- "num-complex 0.2.4",
- "num-rational 0.2.3",
- "num-traits",
- "rand 0.6.5",
- "typenum",
-]
-
-[[package]]
 name = "native-tls"
-version = "0.2.3"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1937,32 +2036,65 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 0.3.4",
- "security-framework-sys 0.3.3",
+ "security-framework 2.3.1",
+ "security-framework-sys 2.3.0",
  "tempfile",
 ]
 
 [[package]]
-name = "net2"
-version = "0.2.33"
+name = "ndk"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+checksum = "8794322172319b972f528bf90c6b467be0079f1fa82780ffb431088e741a73ab"
 dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.8",
+ "jni-sys",
+ "ndk-sys",
+ "num_enum",
+ "thiserror",
 ]
 
 [[package]]
-name = "nix"
-version = "0.9.0"
+name = "ndk-glue"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c5afeb0198ec7be8569d666644b574345aad2e95a53baf3a532da3e0f3fb32"
+checksum = "c5caf0c24d51ac1c905c27d4eda4fa0635bbe0de596b8f79235e0b17a4d29385"
 dependencies = [
- "bitflags 0.9.1",
+ "lazy_static",
+ "libc",
+ "log 0.4.8",
+ "ndk",
+ "ndk-macro",
+ "ndk-sys",
+]
+
+[[package]]
+name = "ndk-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d1c6307dc424d0f65b9b06e94f88248e6305726b14729fd67a5e47b2dc481d"
+dependencies = [
+ "darling 0.10.2",
+ "proc-macro-crate",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c44922cb3dbb1c70b5e5f443d63b64363a898564d739ba5198e3a9138442868d"
+
+[[package]]
+name = "net2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "void",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1979,6 +2111,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
+dependencies = [
+ "bitflags 1.2.1",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,27 +2133,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "num"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
 dependencies = [
  "num-bigint 0.3.1",
- "num-complex 0.3.1",
+ "num-complex",
  "num-integer",
  "num-iter",
- "num-rational 0.3.2",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f115de20ad793e857f76da2563ff4a09fbcfd6fe93cca0c5d996ab5f3ee38d"
-dependencies = [
- "autocfg 1.0.0",
- "num-integer",
+ "num-rational",
  "num-traits",
 ]
 
@@ -2025,13 +2167,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.2.4"
+name = "num-bigint"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
 dependencies = [
  "autocfg 1.0.0",
+ "num-integer",
  "num-traits",
+ "rand 0.8.4",
 ]
 
 [[package]]
@@ -2041,6 +2185,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2058,17 +2213,6 @@ name = "num-iter"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
-dependencies = [
- "autocfg 1.0.0",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4dc79f9e6c81bef96148c8f6b8e72ad4541caa4a24373e900a36da07de03a3"
 dependencies = [
  "autocfg 1.0.0",
  "num-integer",
@@ -2107,16 +2251,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "226b45a5c2ac4dd696ed30fa6b94b057ad909c7b7fc2e0d0808192bced894066"
+dependencies = [
+ "derivative",
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c0fd9eba1d5db0994a239e09c1be402d35622277e35468ba891aa5e3188ce7e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
+
+[[package]]
 name = "object"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
-name = "ogg"
-version = "0.7.0"
+name = "oboe"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79f1db9148be9d0e174bb3ac890f6030fcb1ed947267c5a91ee4c91b5a91e15"
+checksum = "dfa187b38ae20374617b7ad418034ed3dc90ac980181d211518bd03537ae8f8d"
+dependencies = [
+ "jni",
+ "ndk",
+ "ndk-glue",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88e64835aa3f579c08d182526dc34e3907343d5b97e87b71a40ba5bca7aca9e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ogg"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6951b4e8bf21c8193da321bcce9c9dd2e13c858fe078bf9054a288b419ae5d6e"
 dependencies = [
  "byteorder",
 ]
@@ -2140,27 +2329,21 @@ checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.26"
+version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3cc5799d98e1088141b8e01ff760112bbd9f19d850c124500566ca6901a585"
+checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
 dependencies = [
  "bitflags 1.2.1",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
@@ -2172,11 +2355,11 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.53"
+version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f"
+checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 1.0.0",
  "cc",
  "libc",
  "pkg-config",
@@ -2195,9 +2378,20 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api",
- "parking_lot_core",
+ "lock_api 0.3.3",
+ "parking_lot_core 0.6.2",
  "rustc_version",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api 0.4.4",
+ "parking_lot_core 0.8.3",
 ]
 
 [[package]]
@@ -2209,25 +2403,34 @@ dependencies = [
  "cfg-if 0.1.10",
  "cloudabi",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.56",
  "rustc_version",
  "smallvec 0.6.13",
- "winapi 0.3.8",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.9",
+ "smallvec 1.6.1",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "pbkdf2"
-version = "0.3.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
+checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
 dependencies = [
- "base64 0.9.3",
- "byteorder",
- "crypto-mac 0.7.0",
- "hmac 0.7.1",
- "rand 0.5.6",
- "sha2 0.8.1",
- "subtle 1.0.0",
+ "crypto-mac 0.11.0",
+ "hmac 0.11.0",
 ]
 
 [[package]]
@@ -2254,7 +2457,16 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7804a463a8d9572f13453c516a5faea534a2403d7ced2f0c7e100eeff072772c"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 0.4.8",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
+dependencies = [
+ "pin-project-internal 1.0.7",
 ]
 
 [[package]]
@@ -2263,9 +2475,20 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.2",
- "syn 1.0.39",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2282,9 +2505,9 @@ checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -2315,9 +2538,28 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "priority-queue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1340009a04e81f656a4e45e295f0b1191c81de424bf940c865e33577a8e223"
+dependencies = [
+ "autocfg 1.0.0",
+ "indexmap",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -2326,9 +2568,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.19",
- "quote 1.0.2",
- "syn 1.0.39",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
  "version_check 0.9.1",
 ]
 
@@ -2338,23 +2580,18 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.2",
- "syn 1.0.39",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
  "syn-mid",
  "version_check 0.9.1",
 ]
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.11"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
-dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.2",
- "syn 1.0.39",
-]
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
@@ -2373,9 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -2422,47 +2659,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2 1.0.19",
-]
-
-[[package]]
-name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "winapi 0.3.8",
+ "proc-macro2 1.0.27",
 ]
 
 [[package]]
@@ -2481,7 +2682,7 @@ dependencies = [
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2490,11 +2691,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
  "libc",
  "rand_chacha 0.2.1",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -2518,6 +2731,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2538,7 +2761,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -2560,6 +2792,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rand_isaac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2576,7 +2817,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2590,7 +2831,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2619,12 +2860,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d13a3485349981c90c79112a11222c3e6e75de1d52b87a7525b3bf5361420f"
 
 [[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,6 +2873,15 @@ name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+dependencies = [
+ "bitflags 1.2.1",
+]
 
 [[package]]
 name = "regex"
@@ -2658,21 +2902,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e734e891f5b408a29efbf8309e656876276f49ab6a6ac208600b4419bd893d90"
 
 [[package]]
-name = "relay"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
-dependencies = [
- "futures 0.1.29",
-]
-
-[[package]]
 name = "remove_dir_all"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2682,14 +2917,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0e798e19e258bf6c30a304622e3e9ac820e483b06a1857a026e1f109b113fe4"
 dependencies = [
  "base64 0.11.0",
- "bytes 0.5.4",
+ "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "http",
- "http-body",
+ "http-body 0.3.1",
  "hyper 0.13.2",
- "hyper-tls",
+ "hyper-tls 0.4.1",
  "js-sys",
  "lazy_static",
  "log 0.4.8",
@@ -2700,38 +2935,69 @@ dependencies = [
  "pin-project-lite 0.1.4",
  "serde",
  "serde_json",
- "serde_urlencoded",
+ "serde_urlencoded 0.6.1",
  "time",
- "tokio 0.2.11",
+ "tokio 0.2.25",
  "tokio-socks",
  "tokio-tls",
- "url 2.1.1",
+ "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "winreg 0.6.2",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 1.0.1",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body 0.4.2",
+ "hyper 0.14.5",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log 0.4.8",
+ "mime",
+ "native-tls",
+ "percent-encoding 2.1.0",
+ "pin-project-lite 0.2.4",
+ "serde",
+ "serde_urlencoded 0.7.0",
+ "tokio 1.8.1",
+ "tokio-native-tls",
+ "url 2.2.2",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.7.0",
 ]
 
 [[package]]
 name = "rodio"
-version = "0.9.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0f961b254e66d147a7b550c78b01308934c97d807a34b417fd0f5a0a0f3a2d"
+checksum = "b65c2eda643191f6d1bb12ea323a9db8d9ba95374e9be3780b5a9fb5cfb8520f"
 dependencies = [
  "cpal",
- "lazy_static",
- "nalgebra",
 ]
 
 [[package]]
 name = "rpassword"
-version = "3.0.2"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34fa7bcae7fca3c8471e8417088bbc3ad9af8066b0ecf4f3c0d98a0d772716e"
+checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
 dependencies = [
- "kernel32-sys",
  "libc",
- "winapi 0.2.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2752,7 +3018,7 @@ dependencies = [
  "percent-encoding 1.0.1",
  "rand 0.6.5",
  "random",
- "reqwest",
+ "reqwest 0.10.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2797,10 +3063,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 
 [[package]]
-name = "safemem"
-version = "0.3.3"
+name = "same-file"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2809,7 +3078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
 dependencies = [
  "lazy_static",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2820,9 +3089,9 @@ checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 
 [[package]]
 name = "scopeguard"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "secret-service"
@@ -2830,26 +3099,14 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d752040301c251d653aa740dec847e95767ce312cfc469bee85eb13cbf81d8a"
 dependencies = [
- "aes 0.6.0",
- "block-modes 0.7.0",
+ "aes",
+ "block-modes",
  "dbus 0.2.3",
  "hkdf",
  "lazy_static",
  "num",
  "rand 0.7.3",
- "sha2 0.9.2",
-]
-
-[[package]]
-name = "security-framework"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df"
-dependencies = [
- "core-foundation 0.6.4",
- "core-foundation-sys 0.6.2",
- "libc",
- "security-framework-sys 0.3.3",
+ "sha2",
 ]
 
 [[package]]
@@ -2866,12 +3123,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework-sys"
-version = "0.3.3"
+name = "security-framework"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
+checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
- "core-foundation-sys 0.6.2",
+ "bitflags 1.2.1",
+ "core-foundation 0.9.1",
+ "core-foundation-sys 0.8.2",
+ "libc",
+ "security-framework-sys 2.3.0",
 ]
 
 [[package]]
@@ -2881,6 +3142,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
  "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
+dependencies = [
+ "core-foundation-sys 0.8.2",
  "libc",
 ]
 
@@ -2914,9 +3185,9 @@ version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.2",
- "syn 1.0.39",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2939,19 +3210,19 @@ dependencies = [
  "dtoa",
  "itoa",
  "serde",
- "url 2.1.1",
+ "url 2.2.2",
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.8.2"
+name = "serde_urlencoded"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2960,23 +3231,11 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 0.1.10",
  "cpuid-bool",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -2985,11 +3244,11 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpuid-bool",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -3012,25 +3271,15 @@ dependencies = [
 
 [[package]]
 name = "shell-words"
-version = "0.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39acde55a154c4cd3ae048ac78cc21c25f3a0145e44111b523279113dce0d94a"
+checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
 
 [[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
-
-[[package]]
-name = "signal-hook"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9c17dd3ba2d36023a5c9472ecddeda07e27fd0b05436e8c1e0c8f178185652"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
 
 [[package]]
 name = "signal-hook-registry"
@@ -3044,21 +3293,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
-
-[[package]]
-name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-
-[[package]]
-name = "smallvec"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
 
 [[package]]
 name = "smallvec"
@@ -3071,27 +3308,19 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.1.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
- "cfg-if 0.1.10",
  "libc",
- "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
-
-[[package]]
-name = "sourcefile"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 
 [[package]]
 name = "spotifyd"
@@ -3105,22 +3334,24 @@ dependencies = [
  "dbus-tokio",
  "env_logger 0.7.1",
  "fern",
- "futures 0.1.29",
+ "futures 0.3.15",
  "gethostname",
- "hex 0.4.2",
+ "hex",
  "keyring",
  "libc",
  "librespot",
  "log 0.4.8",
  "percent-encoding 2.1.0",
+ "reqwest 0.11.4",
  "rspotify",
  "serde",
- "sha-1 0.9.1",
+ "sha-1",
  "structopt",
  "syslog",
- "tokio-core",
- "tokio-io",
- "tokio-signal 0.1.5",
+ "tokio 1.8.1",
+ "tokio-compat",
+ "tokio-compat-02",
+ "tokio-stream",
  "toml",
  "url 1.7.2",
  "whoami",
@@ -3134,15 +3365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
 
 [[package]]
-name = "stream-cipher"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
-dependencies = [
- "generic-array 0.12.3",
-]
-
-[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,6 +3375,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"
@@ -3173,16 +3401,10 @@ checksum = "5e2513111825077552a6751dfad9e11ce0fba07d7276a3943a037d7e93e64c5f"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.19",
- "quote 1.0.2",
- "syn 1.0.39",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
 ]
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -3203,12 +3425,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.39"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.2",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
  "unicode-xid 0.2.0",
 ]
 
@@ -3218,9 +3440,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.2",
- "syn 1.0.39",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3229,9 +3451,9 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.2",
- "syn 1.0.39",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
  "unicode-xid 0.2.0",
 ]
 
@@ -3241,17 +3463,11 @@ version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0641142b4081d3d44beffa4eefd7346a228cdf91ed70186db2ca2cef762d327"
 dependencies = [
- "error-chain 0.11.0",
+ "error-chain",
  "libc",
  "log 0.4.8",
  "time",
 ]
-
-[[package]]
-name = "take"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 
 [[package]]
 name = "tempfile"
@@ -3262,9 +3478,9 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "rand 0.7.3",
- "redox_syscall",
+ "redox_syscall 0.1.56",
  "remove_dir_all",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3286,6 +3502,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3301,9 +3537,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 dependencies = [
  "libc",
- "redox_syscall",
- "winapi 0.3.8",
+ "redox_syscall 0.1.56",
+ "winapi 0.3.9",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
@@ -3313,7 +3564,7 @@ checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
- "mio",
+ "mio 0.6.23",
  "num_cpus",
  "tokio-codec",
  "tokio-current-thread",
@@ -3331,20 +3582,39 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.11"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
  "memchr",
- "mio",
+ "mio 0.6.23",
  "num_cpus",
  "pin-project-lite 0.1.4",
- "slab 0.4.2",
+ "slab",
+]
+
+[[package]]
+name = "tokio"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+dependencies = [
+ "autocfg 1.0.0",
+ "bytes 1.0.1",
+ "libc",
+ "memchr",
+ "mio 0.7.13",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite 0.2.4",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3359,6 +3629,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-compat"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "107b625135aa7b9297dd2d99ccd6ca6ab124a5d1230778e159b9095adca4c722"
+dependencies = [
+ "futures 0.1.29",
+ "futures-core",
+ "futures-util",
+ "pin-project-lite 0.1.4",
+ "tokio 0.2.25",
+ "tokio-current-thread",
+ "tokio-executor",
+ "tokio-reactor",
+ "tokio-timer",
+]
+
+[[package]]
+name = "tokio-compat-02"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d4237822b7be8fff0a7a27927462fad435dcb6650f95cea9e946bf6bdc7e07"
+dependencies = [
+ "bytes 0.5.6",
+ "once_cell",
+ "pin-project-lite 0.2.4",
+ "tokio 0.2.25",
+ "tokio 1.8.1",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tokio-core"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3368,7 +3669,7 @@ dependencies = [
  "futures 0.1.29",
  "iovec",
  "log 0.4.8",
- "mio",
+ "mio 0.6.23",
  "scoped-tls",
  "tokio 0.1.22",
  "tokio-executor",
@@ -3420,40 +3721,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-process"
-version = "0.2.4"
+name = "tokio-macros"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbd6ef1b8cc2bd2c2b580d882774d443ebb1c6ceefe35ba9ea4ab586c89dbe8"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
- "crossbeam-queue",
- "futures 0.1.29",
- "lazy_static",
- "libc",
- "log 0.4.8",
- "mio",
- "mio-named-pipes",
- "tokio-io",
- "tokio-reactor",
- "tokio-signal 0.2.7",
- "winapi 0.3.8",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
 ]
 
 [[package]]
-name = "tokio-proto"
-version = "0.1.1"
+name = "tokio-native-tls"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
- "futures 0.1.29",
- "log 0.3.9",
- "net2",
- "rand 0.3.23",
- "slab 0.3.0",
- "smallvec 0.2.1",
- "take",
- "tokio-core",
- "tokio-io",
- "tokio-service",
+ "native-tls",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -3466,54 +3751,13 @@ dependencies = [
  "futures 0.1.29",
  "lazy_static",
  "log 0.4.8",
- "mio",
+ "mio 0.6.23",
  "num_cpus",
- "parking_lot",
- "slab 0.4.2",
+ "parking_lot 0.9.0",
+ "slab",
  "tokio-executor",
  "tokio-io",
  "tokio-sync",
-]
-
-[[package]]
-name = "tokio-service"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
-dependencies = [
- "futures 0.1.29",
-]
-
-[[package]]
-name = "tokio-signal"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f46863230f9a05cf52d173721ec391b9c5782a2465f593029922b8782b9ffe"
-dependencies = [
- "futures 0.1.29",
- "libc",
- "mio",
- "mio-uds",
- "tokio-core",
- "tokio-io",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "tokio-signal"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6dc5276ea05ce379a16de90083ec80836440d5ef8a6a39545a3207373b8296"
-dependencies = [
- "futures 0.1.29",
- "libc",
- "mio",
- "mio-uds",
- "signal-hook",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
- "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3526,8 +3770,19 @@ dependencies = [
  "derefable",
  "either",
  "failure",
- "futures 0.3.4",
- "tokio 0.2.11",
+ "futures 0.3.15",
+ "tokio 0.2.25",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.4",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -3549,7 +3804,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
  "iovec",
- "mio",
+ "mio 0.6.23",
  "tokio-io",
  "tokio-reactor",
 ]
@@ -3567,7 +3822,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.8",
  "num_cpus",
- "slab 0.4.2",
+ "slab",
  "tokio-executor",
 ]
 
@@ -3579,7 +3834,7 @@ checksum = "1739638e364e558128461fc1ad84d997702c8e31c2e6b18fb99842268199e827"
 dependencies = [
  "crossbeam-utils 0.6.6",
  "futures 0.1.29",
- "slab 0.4.2",
+ "slab",
  "tokio-executor",
 ]
 
@@ -3590,7 +3845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
 dependencies = [
  "native-tls",
- "tokio 0.2.11",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -3602,7 +3857,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
  "log 0.4.8",
- "mio",
+ "mio 0.6.23",
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
@@ -3619,7 +3874,7 @@ dependencies = [
  "iovec",
  "libc",
  "log 0.4.8",
- "mio",
+ "mio 0.6.23",
  "mio-uds",
  "tokio-codec",
  "tokio-io",
@@ -3632,12 +3887,26 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log 0.4.8",
  "pin-project-lite 0.1.4",
- "tokio 0.2.11",
+ "tokio 0.2.25",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-sink",
+ "log 0.4.8",
+ "pin-project-lite 0.2.4",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -3673,9 +3942,9 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.2",
- "syn 1.0.39",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3707,12 +3976,6 @@ dependencies = [
  "thread_local",
  "tracing-core",
 ]
-
-[[package]]
-name = "try-lock"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
 
 [[package]]
 name = "try-lock"
@@ -3750,7 +4013,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
 dependencies = [
- "smallvec 1.1.0",
+ "smallvec 1.6.1",
 ]
 
 [[package]]
@@ -3790,10 +4053,11 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
+ "form_urlencoded",
  "idna 0.2.0",
  "matches",
  "percent-encoding 2.1.0",
@@ -3801,11 +4065,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "rand 0.6.5",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -3850,14 +4114,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
-name = "want"
-version = "0.0.4"
+name = "walkdir"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05d9d966753fa4b5c8db73fcab5eed4549cfe0e1e4e66911e5564a0085c35d1"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
- "futures 0.1.29",
- "log 0.4.8",
- "try-lock 0.1.0",
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3867,7 +4131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
  "log 0.4.8",
- "try-lock 0.2.2",
+ "try-lock",
 ]
 
 [[package]]
@@ -3877,12 +4141,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.58"
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -3890,26 +4160,26 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.58"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.8",
- "proc-macro2 1.0.19",
- "quote 1.0.2",
- "syn 1.0.39",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.8"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbdd49e3e28b40dec6a9ba8d17798245ce32b019513a845369c641b275135d9"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -3917,60 +4187,41 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.58"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
- "quote 1.0.2",
+ "quote 1.0.9",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.58"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.2",
- "syn 1.0.39",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.58"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e7e61fc929f4c0dddb748b102ebf9f632e2b8d739f2016542b4de2965a9601"
-
-[[package]]
-name = "wasm-bindgen-webidl"
-version = "0.2.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef012a0d93fc0432df126a8eaf547b2dce25a8ce9212e1d3cbeef5c11157975d"
-dependencies = [
- "anyhow",
- "heck",
- "log 0.4.8",
- "proc-macro2 1.0.19",
- "quote 1.0.2",
- "syn 1.0.39",
- "wasm-bindgen-backend",
- "weedle",
-]
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.35"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf97caf6aa8c2b1dac90faf0db529d9d63c93846cca4911856f78a83cebf53b"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
- "anyhow",
  "js-sys",
- "sourcefile",
  "wasm-bindgen",
- "wasm-bindgen-webidl",
 ]
 
 [[package]]
@@ -3980,16 +4231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d468a911faaaeb783693b004e1c62e0063e646b0afae5c146cd144e566e66d"
 dependencies = [
  "widestring",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "weedle"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
-dependencies = [
- "nom",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4012,9 +4254,9 @@ checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -4038,7 +4280,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4053,7 +4295,16 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4071,3 +4322,24 @@ name = "xdg"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
+
+[[package]]
+name = "zerocopy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6580539ad917b7c026220c4b3f2c08d52ce54d6ce0dc491e66002e35388fab46"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "syn 1.0.73",
+ "synstructure",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,24 +14,26 @@ daemonize = "0.4"
 dbus = { version = "0.6", optional = true }
 dbus-tokio = { version = "0.2", optional = true }
 fern = { version = "0.6.0", features = ["syslog-4"] }
-futures = "0.1"
+futures = "0.3.15"
 gethostname = "0.2.0"
 hex = "0.4"
 keyring = { version = "0.10.1", optional = true }
 libc = "0.2.82"
 log = "0.4.6"
 percent-encoding = "2.1.0"
+reqwest = "0.11.3"
 rspotify = "0.8.0"
 serde = { version = "1.0.115", features = ["derive"] }
 sha-1 = "0.9"
 structopt = "0.3.17"
 syslog = "4"
-tokio-core = "0.1"
-tokio-io = "0.1"
-tokio-signal = "0.1"
+tokio = "1.6.1"
+tokio-compat = { version = "0.1.6", features = ["rt-current-thread"] }
+tokio-compat-02 = "0.2.0"
+tokio-stream = "0.1.7"
 url = "1.7"
 xdg = "2.2"
-librespot = { version = "0.1.5", default-features = false, features = ["with-tremor"] }
+librespot = { version = "0.2.0", default-features = false, features = ["with-tremor"] }
 toml = "0.5.8"
 color-eyre = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ version = "0.3.2"
 alsa = { version = "0.3", optional = true }
 chrono = "0.4"
 daemonize = "0.4"
-dbus = { version = "0.6", optional = true }
-dbus-tokio = { version = "0.2", optional = true }
+dbus = { version = "0.9", optional = true }
+dbus-tokio = { version = "0.7.3", optional = true }
+dbus-crossroads = { version = "0.4.0", optional = true }
 fern = { version = "0.6.0", features = ["syslog-4"] }
 futures = "0.3.15"
 gethostname = "0.2.0"
@@ -46,7 +47,7 @@ env_logger = "0.7"
 [features]
 alsa_backend = ["librespot/alsa-backend", "alsa"]
 dbus_keyring = ["keyring"]
-dbus_mpris = ["dbus", "dbus-tokio"]
+dbus_mpris = ["dbus", "dbus-tokio", "dbus-crossroads"]
 default = ["alsa_backend"]
 portaudio_backend = ["librespot/portaudio-backend"]
 pulseaudio_backend = ["librespot/pulseaudio-backend"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-only"
 version = "0.3.2"
 
 [dependencies]
-alsa = { version = "0.3", optional = true }
+alsa = { version = "0.5", optional = true }
 chrono = "0.4"
 daemonize = "0.4"
 dbus = { version = "0.9", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,16 @@ serde = { version = "1.0.115", features = ["derive"] }
 sha-1 = "0.9"
 structopt = "0.3.17"
 syslog = "4"
-tokio = "1.6.1"
+tokio = {version = "1.6.1", features = ["signal", "rt-multi-thread"] }
 tokio-compat = { version = "0.1.6", features = ["rt-current-thread"] }
 tokio-compat-02 = "0.2.0"
 tokio-stream = "0.1.7"
 url = "1.7"
 xdg = "2.2"
-librespot = { version = "0.2.0", default-features = false, features = ["with-tremor"] }
+librespot-audio = { version = "0.2.0", default-features=false, features = ["with-tremor"] }
+librespot-playback = { version = "0.2.0", default-features=false }
+librespot-core = { version = "0.2.0"}
+librespot-connect = { version = "0.2.0"}
 toml = "0.5.8"
 color-eyre = "0.5"
 
@@ -45,13 +48,13 @@ whoami = "0.9.0"
 env_logger = "0.7"
 
 [features]
-alsa_backend = ["librespot/alsa-backend", "alsa"]
+alsa_backend = ["librespot-playback/alsa-backend", "alsa"]
 dbus_keyring = ["keyring"]
 dbus_mpris = ["dbus", "dbus-tokio", "dbus-crossroads"]
 default = ["alsa_backend"]
-portaudio_backend = ["librespot/portaudio-backend"]
-pulseaudio_backend = ["librespot/pulseaudio-backend"]
-rodio_backend = ["librespot/rodio-backend"]
+portaudio_backend = ["librespot-playback/portaudio-backend"]
+pulseaudio_backend = ["librespot-playback/pulseaudio-backend"]
+rodio_backend = ["librespot-playback/rodio-backend"]
 
 [package.metadata.deb]
 depends = "$auto, systemd, pulseaudio"

--- a/src/alsa_mixer.rs
+++ b/src/alsa_mixer.rs
@@ -1,4 +1,4 @@
-use librespot::playback::mixer::{AudioFilter, Mixer, MixerConfig};
+use librespot_playback::mixer::{AudioFilter, Mixer, MixerConfig};
 use log::error;
 use std::error::Error;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,10 +5,8 @@ use crate::{
 };
 use color_eyre::Report;
 use gethostname::gethostname;
-use librespot::{
-    core::{cache::Cache, config::DeviceType as LSDeviceType, config::SessionConfig, version},
-    playback::config::{Bitrate as LSBitrate, PlayerConfig},
-};
+use librespot_core::{cache::Cache, config::DeviceType as LSDeviceType, config::SessionConfig, version};
+use librespot_playback::config::{Bitrate as LSBitrate, PlayerConfig};
 use log::{error, info, warn};
 use reqwest::Url;
 use serde::{de::Error, de::Unexpected, Deserialize, Deserializer};

--- a/src/config.rs
+++ b/src/config.rs
@@ -393,6 +393,7 @@ impl FileConfig {
         // section.
         if let Some(mut spotifyd_section) = spotifyd_config_section {
             // spotifyd section exists. Try to merge it with global section.
+            #[allow(clippy::branches_sharing_code)]
             if let Some(global_section) = global_config_section {
                 spotifyd_section.merge_with(global_section);
                 merged_config = Some(spotifyd_section);

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,9 @@ use crate::{
 };
 use color_eyre::Report;
 use gethostname::gethostname;
-use librespot_core::{cache::Cache, config::DeviceType as LSDeviceType, config::SessionConfig, version};
+use librespot_core::{
+    cache::Cache, config::DeviceType as LSDeviceType, config::SessionConfig, version,
+};
 use librespot_playback::config::{Bitrate as LSBitrate, PlayerConfig};
 use log::{error, info, warn};
 use reqwest::Url;

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,11 +10,11 @@ use librespot::{
     playback::config::{Bitrate as LSBitrate, PlayerConfig},
 };
 use log::{error, info, warn};
+use reqwest::Url;
 use serde::{de::Error, de::Unexpected, Deserialize, Deserializer};
 use sha1::{Digest, Sha1};
 use std::{fmt, fs, path::PathBuf, str::FromStr, string::ToString};
 use structopt::{clap::AppSettings, StructOpt};
-use reqwest::Url;
 
 const CONFIG_FILE_NAME: &str = "spotifyd.conf";
 
@@ -580,7 +580,19 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         .map(PathBuf::from)
         // TODO: plumb size limits, check audio_cache?
         // TODO: rather than silently disabling cache if constructor fails, maybe we should handle the error?
-        .map(|path| Cache::new(Some(path.clone()), if audio_cache { Some(path.clone()) } else { None }, None).ok()).flatten();
+        .map(|path| {
+            Cache::new(
+                Some(path.clone()),
+                if audio_cache {
+                    Some(path.clone())
+                } else {
+                    None
+                },
+                None,
+            )
+            .ok()
+        })
+        .flatten();
 
     let bitrate: LSBitrate = config
         .shared_config

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,9 +114,12 @@ pub enum DeviceType {
     Tablet = 2,
     Smartphone = 3,
     Speaker = 4,
-    TV = 5,
-    AVR = 6,
-    STB = 7,
+    #[serde(rename = "t_v")]
+    Tv = 5,
+    #[serde(rename = "a_v_r")]
+    Avr = 6,
+    #[serde(rename = "s_t_b")]
+    Stb = 7,
     AudioDongle = 8,
 }
 
@@ -128,9 +131,9 @@ impl From<LSDeviceType> for DeviceType {
             LSDeviceType::Tablet => DeviceType::Tablet,
             LSDeviceType::Smartphone => DeviceType::Smartphone,
             LSDeviceType::Speaker => DeviceType::Speaker,
-            LSDeviceType::Tv => DeviceType::TV,
-            LSDeviceType::Avr => DeviceType::AVR,
-            LSDeviceType::Stb => DeviceType::STB,
+            LSDeviceType::Tv => DeviceType::Tv,
+            LSDeviceType::Avr => DeviceType::Avr,
+            LSDeviceType::Stb => DeviceType::Stb,
             LSDeviceType::AudioDongle => DeviceType::AudioDongle,
             // TODO: Implement new LibreSpot device types in Spotifyd
             _ => DeviceType::Unknown,
@@ -146,9 +149,9 @@ impl From<&DeviceType> for LSDeviceType {
             DeviceType::Tablet => LSDeviceType::Tablet,
             DeviceType::Smartphone => LSDeviceType::Smartphone,
             DeviceType::Speaker => LSDeviceType::Speaker,
-            DeviceType::TV => LSDeviceType::Tv,
-            DeviceType::AVR => LSDeviceType::Avr,
-            DeviceType::STB => LSDeviceType::Stb,
+            DeviceType::Tv => LSDeviceType::Tv,
+            DeviceType::Avr => LSDeviceType::Avr,
+            DeviceType::Stb => LSDeviceType::Stb,
             DeviceType::AudioDongle => LSDeviceType::AudioDongle,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -701,6 +701,9 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         pc.bitrate = bitrate;
         pc.normalisation = config.shared_config.volume_normalisation;
         pc.normalisation_pregain = normalisation_pregain;
+        // Sensible default; the "default" supplied by PlayerConfig::default() sets this to -1.0,
+        // which turns the output to garbage.
+        pc.normalisation_threshold = 1.0;
         pc.gapless = true;
         pc
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ use serde::{de::Error, de::Unexpected, Deserialize, Deserializer};
 use sha1::{Digest, Sha1};
 use std::{fmt, fs, path::PathBuf, str::FromStr, string::ToString};
 use structopt::{clap::AppSettings, StructOpt};
-use url::Url;
+use reqwest::Url;
 
 const CONFIG_FILE_NAME: &str = "spotifyd.conf";
 
@@ -128,10 +128,12 @@ impl From<LSDeviceType> for DeviceType {
             LSDeviceType::Tablet => DeviceType::Tablet,
             LSDeviceType::Smartphone => DeviceType::Smartphone,
             LSDeviceType::Speaker => DeviceType::Speaker,
-            LSDeviceType::TV => DeviceType::TV,
-            LSDeviceType::AVR => DeviceType::AVR,
-            LSDeviceType::STB => DeviceType::STB,
+            LSDeviceType::Tv => DeviceType::TV,
+            LSDeviceType::Avr => DeviceType::AVR,
+            LSDeviceType::Stb => DeviceType::STB,
             LSDeviceType::AudioDongle => DeviceType::AudioDongle,
+            // TODO: Implement new LibreSpot device types in Spotifyd
+            _ => DeviceType::Unknown,
         }
     }
 }
@@ -144,9 +146,9 @@ impl From<&DeviceType> for LSDeviceType {
             DeviceType::Tablet => LSDeviceType::Tablet,
             DeviceType::Smartphone => LSDeviceType::Smartphone,
             DeviceType::Speaker => LSDeviceType::Speaker,
-            DeviceType::TV => LSDeviceType::TV,
-            DeviceType::AVR => LSDeviceType::AVR,
-            DeviceType::STB => LSDeviceType::STB,
+            DeviceType::TV => LSDeviceType::Tv,
+            DeviceType::AVR => LSDeviceType::Avr,
+            DeviceType::STB => LSDeviceType::Stb,
             DeviceType::AudioDongle => LSDeviceType::AudioDongle,
         }
     }
@@ -419,7 +421,7 @@ impl fmt::Debug for SharedConfigValues {
                     None => None,
                 }
             };
-        };
+        }
 
         let password_value = extract_credential!(&self.password);
 
@@ -576,7 +578,9 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         .shared_config
         .cache_path
         .map(PathBuf::from)
-        .map(|path| Cache::new(path, audio_cache));
+        // TODO: plumb size limits, check audio_cache?
+        // TODO: rather than silently disabling cache if constructor fails, maybe we should handle the error?
+        .map(|path| Cache::new(Some(path.clone()), if audio_cache { Some(path.clone()) } else { None }, None).ok()).flatten();
 
     let bitrate: LSBitrate = config
         .shared_config
@@ -676,6 +680,19 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         },
         None => info!("No proxy specified"),
     }
+
+    // TODO: when we were on librespot 0.1.5, all PlayerConfig values were available in the
+    //  Spotifyd config. The upgrade to librespot 0.2.0 introduces new config variables, and we
+    //  should consider adding them to Spotifyd's config system.
+    let pc = {
+        let mut pc = PlayerConfig::default();
+        pc.bitrate = bitrate;
+        pc.normalisation = config.shared_config.volume_normalisation;
+        pc.normalisation_pregain = normalisation_pregain;
+        pc.gapless = true;
+        pc
+    };
+
     SpotifydConfig {
         username,
         password,
@@ -689,14 +706,9 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         volume_controller,
         initial_volume,
         device_name,
-        player_config: PlayerConfig {
-            bitrate,
-            normalisation: config.shared_config.volume_normalisation,
-            normalisation_pregain,
-            gapless: true,
-        },
+        player_config: pc,
         session_config: SessionConfig {
-            user_agent: version::version_string(),
+            user_agent: version::VERSION_STRING.to_string(),
             device_id,
             proxy: proxy_url,
             ap_port: Some(443),

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -26,6 +26,7 @@ pub struct DbusServer {
     session: Session,
     spirc: Arc<Spirc>,
     api_token: RspotifyToken,
+    #[allow(clippy::type_complexity)]
     token_request: Option<Pin<Box<dyn Future<Output = Result<LibrespotToken, MercuryError>>>>>,
     dbus_future: Option<Pin<Box<dyn Future<Output = ()>>>>,
     device_name: String,
@@ -420,7 +421,7 @@ async fn create_dbus_server(api_token: RspotifyToken, spirc: Arc<Spirc>, device_
                                     .external_urls
                                     .iter()
                                     .next()
-                                    .map_or("", |(_, v)| &v)
+                                    .map_or("", |(_, v)| v)
                                     .to_string(),
                             )),
                         );
@@ -432,7 +433,7 @@ async fn create_dbus_server(api_token: RspotifyToken, spirc: Arc<Spirc>, device_
                 Ok(m)
             });
 
-        for prop in vec![
+        for prop in &[
             "CanPlay",
             "CanPause",
             "CanSeek",
@@ -440,7 +441,7 @@ async fn create_dbus_server(api_token: RspotifyToken, spirc: Arc<Spirc>, device_
             "CanGoPrevious",
             "CanGoNext",
         ] {
-            b.property(prop).emits_changed_const().get(|_, _| Ok(true));
+            b.property(*prop).emits_changed_const().get(|_, _| Ok(true));
         }
     });
 

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -441,7 +441,7 @@ async fn create_dbus_server(api_token: RspotifyToken, spirc: Arc<Spirc>, device_
         }
     });
 
-    cr.insert("/", &[media_player2_interface, player_interface], ());
+    cr.insert("/org/mpris/MediaPlayer2", &[media_player2_interface, player_interface], ());
 
     conn.start_receive(
         MatchRule::new_method_call(),

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -79,6 +79,11 @@ impl Future for DbusServer {
                         self.spirc.clone(),
                         self.device_name.clone(),
                     )));
+                    // TODO: for reasons I don't _entirely_ understand, the token request completing
+                    // convinces callers that they don't need to re-check the status of this future
+                    // until we start playing. This causes DBUS to not respond until that point in
+                    // time. So, fire a "wake" here, which tells callers to keep checking.
+                    cx.waker().clone().wake();
                     got_new_token = true;
                 }
             } else {

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -6,13 +6,11 @@ use dbus_crossroads::{Crossroads, IfaceToken};
 use dbus_tokio::connection;
 use futures::task::{Context, Poll};
 use futures::{self, Future};
-use librespot::{
-    connect::spirc::Spirc,
-    core::{
-        keymaster::{get_token, Token as LibrespotToken},
-        mercury::MercuryError,
-        session::Session,
-    },
+use librespot_connect::spirc::Spirc;
+use librespot_core::{
+    keymaster::{get_token, Token as LibrespotToken},
+    mercury::MercuryError,
+    session::Session,
 };
 use log::info;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -1,15 +1,5 @@
 use chrono::prelude::*;
-use dbus::{
-    arg::{RefArg, Variant},
-    tree::{Access, MethodErr},
-    BusType, Connection, MessageItem, MessageItemArray, NameFlag, Signature,
-};
-use dbus_tokio::{
-    tree::{AFactory, ATree, ATreeServer},
-    AConnection,
-};
-use futures::{self, Future, FutureExt};
-use futures::channel::oneshot;
+use futures::{self, Future};
 use librespot::{
     connect::spirc::Spirc,
     core::{
@@ -18,19 +8,25 @@ use librespot::{
         session::Session,
     },
 };
-use log::{info, warn};
+use log::info;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use rspotify::spotify::{
     client::Spotify, model::offset::for_position, oauth2::TokenInfo as RspotifyToken, senum::*,
     util::datetime_to_timestamp,
 };
-use std::{collections::HashMap, env, rc::Rc, thread};
+use std::{collections::HashMap, env};
 use std::pin::Pin;
 use futures::task::{Context, Poll};
+use dbus_tokio::connection;
+use std::sync::Arc;
+use dbus::channel::MatchingReceiver;
+use dbus::message::MatchRule;
+use dbus_crossroads::{Crossroads, IfaceToken};
+use dbus::arg::{Variant, RefArg};
 
 pub struct DbusServer {
     session: Session,
-    spirc: Rc<Spirc>,
+    spirc: Arc<Spirc>,
     api_token: RspotifyToken,
     token_request: Option<Pin<Box<dyn Future<Output=Result<LibrespotToken, MercuryError>>>>>,
     dbus_future: Option<Pin<Box<dyn Future<Output = ()>>>>,
@@ -48,7 +44,7 @@ const SCOPE: &str = "user-read-playback-state,user-read-private,\
 impl DbusServer {
     pub fn new(
         session: Session,
-        spirc: Rc<Spirc>,
+        spirc: Arc<Spirc>,
         device_name: String,
     ) -> DbusServer {
         DbusServer {
@@ -82,18 +78,23 @@ impl Future for DbusServer {
                         .access_token(&token.access_token)
                         .expires_in(token.expires_in)
                         .expires_at(datetime_to_timestamp(token.expires_in));
-                    self.dbus_future = Some(create_dbus_server(
+                    self.dbus_future = Some(Box::pin(create_dbus_server(
                         self.api_token.clone(),
                         self.spirc.clone(),
                         self.device_name.clone(),
-                    ));
+                    )));
                     got_new_token = true;
                 }
             } else {
-                // This is more meant as a fast hotfix than anything else!
-                let client_id =
-                    env::var("SPOTIFYD_CLIENT_ID").unwrap_or_else(|_| CLIENT_ID.to_string());
-                self.token_request = Some(Box::pin(get_token(&self.session.clone(), &client_id, SCOPE)));
+                self.token_request = Some(Box::pin({
+                    let sess = self.session.clone();
+                    // This is more meant as a fast hotfix than anything else!
+                    let client_id =
+                            env::var("SPOTIFYD_CLIENT_ID").unwrap_or_else(|_| CLIENT_ID.to_string());
+                    async move {
+                        get_token(&sess, &client_id, SCOPE).await
+                    }
+                }));
             }
         } else if let Some(ref mut fut) = self.dbus_future {
             return fut.as_mut().poll(cx);
@@ -111,246 +112,136 @@ fn create_spotify_api(token: &RspotifyToken) -> Spotify {
     Spotify::default().access_token(&token.access_token).build()
 }
 
-fn create_dbus_server(
+async fn create_dbus_server(
     api_token: RspotifyToken,
-    spirc: Rc<Spirc>,
+    spirc: Arc<Spirc>,
     device_name: String,
-) -> Pin<Box<dyn Future<Output = ()>>> {
-    macro_rules! spotify_api_method {
-        ([ $sp:ident, $device:ident $(, $m:ident: $t:ty)*] $f:expr) => {
-            {
-                let device_name = utf8_percent_encode(&device_name, NON_ALPHANUMERIC).to_string();
-                let token = api_token.clone();
-                move |m| {
-                    let (tx, rx) = oneshot::channel();
-                    let token = token.clone();
-                    let device_name = device_name.clone();
-                    $(let $m: Result<$t,_> = m.msg.read1();)*
-                    thread::spawn(move || {
-                        let $sp = create_spotify_api(&token);
-                        let $device = Some(device_name);
-                        let _ = $f;
-                        let _ = tx.send(());
-                    });
-                    let mret = m.msg.method_return();
-                    rx.map(|val| match val {
-                        Ok(_) => Ok(vec![mret]),
-                        Err(e) => Err(MethodErr::failed(&e)),
-                    }).into()
-                }
-            }
-        }
-    }
-
-    macro_rules! spotify_api_property {
-        ([ $sp:ident, $device:ident] $f:expr) => {{
-            let device_name = utf8_percent_encode(&device_name, NON_ALPHANUMERIC).to_string();
-            let token = api_token.clone();
-            move |i, _| {
-                let $sp = create_spotify_api(&token);
-                let $device = Some(device_name.clone());
-                let v = $f;
-                i.append(v);
-                Ok(())
-            }
-        }};
-    }
-
+) {
     // TODO: allow other DBus types through CLI and config entry.
-    let connection = Rc::new(
-        Connection::get_private(BusType::Session).expect("Failed to initialize DBus connection"),
-    );
+    let (resource, conn) = connection::new_session_sync().expect("Failed to initialize DBus connection");
+    tokio::spawn(async {
+        let err = resource.await;
+        panic!("Lost connection to D-Bus: {}", err);
+    });
 
-    connection
-        .register_name(
-            "org.mpris.MediaPlayer2.spotifyd",
-            NameFlag::ReplaceExisting as u32,
-        )
-        .expect("Failed to register dbus player name");
+    conn.request_name(
+        "org.mpris.MediaPlayer2.spotifyd",
+        false,
+        true,
+        true
+    ).await.expect("Failed to register dbus player name");
 
-    // The tree is asynchronuous so we can fetch data over the spotify web api.
-    let f = AFactory::new_afn::<()>();
+    let mut cr = Crossroads::new();
+    cr.set_async_support(Some((conn.clone(), Box::new(|x| { tokio::spawn(x); }))));
 
     // The following methods and properties are part of the MediaPlayer2 interface.
     // https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html
-    let property_can_quit = f
-        .property::<bool, _>("CanQuit", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(true);
-            Ok(())
+    let media_player2_interface = cr
+        .register("org.mpris.MediaPlayer2", |b| {
+           b.method("Raise", (), (), move |_,_,():()| {
+               // noop
+               Ok(())
+           });
+            let local_spirc = spirc.clone();
+            b.method("Quit", (), (), move |_,_,():()| {
+                local_spirc.shutdown();
+                Ok(())
+            });
+            b.property("CanQuit")
+                .emits_changed_const()
+                .get(|_,_| Ok(true));
+            b.property("CanRaise")
+                .emits_changed_const()
+                .get(|_,_| Ok(false));
+            b.property("CanSetFullscreen")
+                .emits_changed_const()
+                .get(|_,_| Ok(false));
+            b.property("HasTrackList")
+                .emits_changed_const()
+                .get(|_,_| Ok(false));
+            b.property("Identity")
+                .emits_changed_const()
+                .get(|_,_| Ok("Spotifyd".to_string()));
+            b.property("SupportedUriSchemes")
+                .emits_changed_const()
+                .get(|_,_| Ok(vec!["spotify".to_string()]));
+            b.property("SupportedMimeTypes")
+                .emits_changed_const()
+                .get(|_,_| Ok(Vec::<String>::new()));
         });
-
-    let property_can_raise = f
-        .property::<bool, _>("CanRaise", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(false);
-            Ok(())
-        });
-
-    let property_can_fullscreen = f
-        .property::<bool, _>("CanSetFullscreen", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(false);
-            Ok(())
-        });
-
-    let property_has_tracklist = f
-        .property::<bool, _>("HasTrackList", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(false);
-            Ok(())
-        });
-
-    let property_identity = f
-        .property::<String, _>("Identity", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append("Spotifyd".to_string());
-            Ok(())
-        });
-
-    let property_supported_uri_schemes = f
-        .property::<Vec<String>, _>("SupportedUriSchemes", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(vec!["spotify".to_string()]);
-            Ok(())
-        });
-
-    let property_mimetypes = f
-        .property::<Vec<String>, _>("SupportedMimeTypes", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(Vec::<String>::new());
-            Ok(())
-        });
-
-    let method_raise = f.amethod("Raise", (), move |m| {
-        let mret = m.msg.method_return();
-        Ok(vec![mret])
-    });
-
-    let method_quit = {
-        let local_spirc = spirc.clone();
-        f.amethod("Quit", (), move |m| {
-            local_spirc.shutdown();
-            let mret = m.msg.method_return();
-            Ok(vec![mret])
-        })
-    };
-
-    let media_player2_interface = f
-        .interface("org.mpris.MediaPlayer2", ())
-        .add_m(method_raise)
-        .add_m(method_quit)
-        .add_p(property_can_quit)
-        .add_p(property_can_raise)
-        .add_p(property_can_fullscreen)
-        .add_p(property_has_tracklist)
-        .add_p(property_identity)
-        .add_p(property_supported_uri_schemes)
-        .add_p(property_mimetypes);
 
     // The following methods and properties are part of the MediaPlayer2.Player interface.
     // https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html
 
-    let method_volume_up = {
-        let local_spirc = spirc.clone();
-        f.amethod("VolumeUp", (), move |m| {
-            local_spirc.volume_up();
-            Ok(vec![m.msg.method_return()])
-        })
-    };
+    let player_interface: IfaceToken<()> = cr
+        .register("org.mpris.MediaPlayer2.Player", |b| {
+            let local_spirc = spirc.clone();
+            b.method("VolumeUp", (), (), move |_,_,():()| {
+                local_spirc.volume_up();
+                Ok(())
+            });
+            let local_spirc = spirc.clone();
+            b.method("VolumeDown", (), (), move |_,_,():()| {
+                local_spirc.volume_down();
+                Ok(())
+            });
+            let local_spirc = spirc.clone();
+            b.method("Next", (), (), move |_,_,():()| {
+                local_spirc.next();
+                Ok(())
+            });
+            let local_spirc = spirc.clone();
+            b.method("Previous", (), (), move |_,_,():()| {
+                local_spirc.prev();
+                Ok(())
+            });
+            let local_spirc = spirc.clone();
+            b.method("Pause", (), (), move |_,_,():()| {
+                local_spirc.pause();
+                Ok(())
+            });
+            let local_spirc = spirc.clone();
+            b.method("PlayPause", (), (), move |_,_,():()| {
+                local_spirc.play_pause();
+                Ok(())
+            });
+            let local_spirc = spirc.clone();
+            b.method("Play", (), (), move |_,_,():()| {
+                local_spirc.play();
+                Ok(())
+            });
+            let local_spirc = spirc.clone();
+            b.method("Stop", (), (), move |_,_,():()| {
+                // TODO: add real stop implementation.
+                local_spirc.pause();
+                Ok(())
+            });
 
-    let method_volume_down = {
-        let local_spirc = spirc.clone();
-        f.amethod("VolumeDown", (), move |m| {
-            local_spirc.volume_down();
-            Ok(vec![m.msg.method_return()])
-        })
-    };
-    
-    let method_next = {
-        let local_spirc = spirc.clone();
-        f.amethod("Next", (), move |m| {
-            local_spirc.next();
-            Ok(vec![m.msg.method_return()])
-        })
-    };
-
-    let method_previous = {
-        let local_spirc = spirc.clone();
-        f.amethod("Previous", (), move |m| {
-            local_spirc.prev();
-            Ok(vec![m.msg.method_return()])
-        })
-    };
-
-    let method_pause = {
-        let local_spirc = spirc.clone();
-        f.method("Pause", (), move |m| {
-            local_spirc.pause();
-            Ok(vec![m.msg.method_return()])
-        })
-    };
-
-    let method_play_pause = {
-        let local_spirc = spirc.clone();
-        f.amethod("PlayPause", (), move |m| {
-            local_spirc.play_pause();
-            Ok(vec![m.msg.method_return()])
-        })
-    };
-
-    let method_play = {
-        let local_spirc = spirc.clone();
-        f.method("Play", (), move |m| {
-            local_spirc.play();
-            Ok(vec![m.msg.method_return()])
-        })
-    };
-
-    let method_stop = {
-        let local_spirc = spirc;
-        f.amethod("Stop", (), move |m| {
-            // TODO: add real stop implementation.
-            local_spirc.pause();
-            Ok(vec![m.msg.method_return()])
-        })
-    };
-
-    let method_seek = f.amethod(
-        "Seek",
-        (),
-        spotify_api_method!([sp, device, pos: u32]{
-            if let Ok(p) = pos {
+            let mv_device_name = device_name.clone();
+            let mv_api_token = api_token.clone();
+            b.method("Seek", ("pos",), (), move |_,_,(pos,):(u32,)| {
+                let device_name = utf8_percent_encode(&mv_device_name, NON_ALPHANUMERIC).to_string();
+                let sp = create_spotify_api(&mv_api_token);
                 if let Ok(Some(playing)) = sp.current_user_playing_track() {
-                    let _ = sp.seek_track(playing.progress_ms.unwrap_or(0) + p, device);
+                    let _ = sp.seek_track(playing.progress_ms.unwrap_or(0) + pos, Some(device_name));
                 }
-            }
-        }),
-    );
+                Ok(())
+            });
 
-    let method_set_position = f.amethod(
-        "SetPosition",
-        (),
-        spotify_api_method!([sp, device, pos: u32]
-            if let Ok(p) = pos {
-                let _ = sp.seek_track(p, device);
-            }
-        ),
-    );
+            let mv_device_name = device_name.clone();
+            let mv_api_token = api_token.clone();
+            b.method("SetPosition", ("pos",), (), move |_,_,(pos,):(u32,)| {
+                let device_name = utf8_percent_encode(&mv_device_name, NON_ALPHANUMERIC).to_string();
+                let sp = create_spotify_api(&mv_api_token);
+                let _ = sp.seek_track(pos, Some(device_name));
+                Ok(())
+            });
 
-    let method_open_uri = f.amethod(
-        "OpenUri",
-        (),
-        spotify_api_method!([sp, device, uri: String]
-            if let Ok(uri) = uri {
-                let device_name = device.unwrap_or_else(|| "".to_owned());
+            let mv_device_name = device_name.clone();
+            let mv_api_token = api_token.clone();
+            b.method("OpenUri", ("uri",), (), move |_,_,(uri,):(String,)| {
+                let device_name = utf8_percent_encode(&mv_device_name, NON_ALPHANUMERIC).to_string();
+                let sp = create_spotify_api(&mv_api_token);
                 let device_id = match sp.device() {
                     Ok(device_payload) => {
                         match device_payload.devices.into_iter().find(|d| d.is_active && d.name == device_name) {
@@ -366,292 +257,179 @@ fn create_dbus_server(
                 } else {
                     let _ = sp.start_playback(device_id, Some(uri), None, for_position(0), None);
                 }
-            }
-        ),
-    );
+                Ok(())
+            });
 
-    let property_playback_status = f
-        .property::<String, _>("PlaybackStatus", ())
-        .access(Access::Read)
-        .on_get(spotify_api_property!([sp, _device]
+            let mv_device_name = device_name.clone();
+            let mv_api_token = api_token.clone();
+            b.property("PlaybackStatus")
+                .emits_changed_false()
+                .get(move |_,_| {
+                    let sp = create_spotify_api(&mv_api_token);
                     if let Ok(Some(player)) = sp.current_playback(None) {
-                        let device_name = utf8_percent_encode(&player.device.name, NON_ALPHANUMERIC).to_string();
-                        if device_name == _device.unwrap() {
+                        if player.device.name == mv_device_name {
                             if let Ok(Some(track)) = sp.current_user_playing_track() {
                                 if track.is_playing {
-                                    "Playing"
+                                    return Ok("Playing".to_string())
                                 } else {
-                                    "Paused"
+                                    return Ok("Paused".to_string())
                                 }
-                            } else {
-                                "Stopped"
                             }
-                        } else {
-                            "Stopped"
+                        }
+                    }
+                    Ok("Stopped".to_string())
+                });
+
+            let mv_api_token = api_token.clone();
+            b.property("Shuffle")
+                .emits_changed_false()
+                .get(move |_,_| {
+                    let sp = create_spotify_api(&mv_api_token);
+                    let shuffle_status = sp.current_playback(None).ok().flatten().map_or(false, |p| p.shuffle_state);
+                    Ok(shuffle_status)
+                });
+
+            b.property("Rate")
+                .emits_changed_const()
+                .get(|_,_| {
+                    Ok(1.0)
+                });
+
+            let mv_api_token = api_token.clone();
+            b.property("Volume")
+                .emits_changed_false()
+                .get(move |_,_| {
+                    let sp = create_spotify_api(&mv_api_token);
+                    let vol = sp.current_playback(None).ok().flatten().map_or(0.0, |p| p.device.volume_percent as f64);
+                    Ok(vol)
+                });
+
+            b.property("MaximumRate")
+                .emits_changed_const()
+                .get(|_,_| {
+                    Ok(1.0)
+                });
+            b.property("MinimumRate")
+                .emits_changed_const()
+                .get(|_,_| {
+                    Ok(1.0)
+                });
+
+            let mv_api_token = api_token.clone();
+            b.property("LoopStatus")
+                .emits_changed_false()
+                .get(move |_,_| {
+                    let sp = create_spotify_api(&mv_api_token);
+                    let status = if let Ok(Some(player)) = sp.current_playback(None) {
+                        match player.repeat_state {
+                            RepeatState::Off => "None",
+                            RepeatState::Track => "Track",
+                            RepeatState::Context => "Playlist",
                         }
                     } else {
-                        "Stopped"
-                    }.to_string()));
+                        "None"
+                    }.to_string();
+                    Ok(status)
+                });
 
-    let property_shuffle = f
-        .property::<bool, _>("Shuffle", ())
-        .access(Access::Read)
-        .on_get(spotify_api_property!([sp, _device]
-            if let Ok(Some(player)) = sp.current_playback(None) {
-                player.shuffle_state
-            } else {
-                false
+            let mv_api_token = api_token.clone();
+            b.property("Position")
+                .emits_changed_false()
+                .get(move |_,_| {
+                    let sp = create_spotify_api(&mv_api_token);
+                    let val = if let Ok(Some(pos)) =
+                    sp.current_playback(None)
+                        .map(|maybe_player| maybe_player.and_then(|p| p.progress_ms)) {
+                        i64::from(pos) * 1000
+                    } else {
+                        0
+                    };
+                    Ok(val)
+                });
+
+            let mv_api_token = api_token.clone();
+            b.property("Metadata")
+                .emits_changed_false()
+                .get(move |_, _| {
+                    let sp = create_spotify_api(&mv_api_token);
+
+                    let mut m: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+                    let v = sp.current_user_playing_track();
+
+                    if let Ok(Some(playing)) = v {
+                        if let Some(track) = playing.item {
+                            m.insert("mpris:trackid".to_string(), Variant(Box::new(track.uri)));
+
+                            m.insert("mpris:length".to_string(), Variant(Box::new(i64::from(track.duration_ms) * 1000)));
+
+                            m.insert("mpris:artUrl".to_string(), Variant(Box::new(
+                                track.album.images
+                                    .first()
+                                    .unwrap().url.clone()
+                            )));
+
+                            m.insert("xesam:title".to_string(), Variant(Box::new(
+                                track.name
+                            )));
+
+                            m.insert("xesam:album".to_string(), Variant(Box::new(
+                                track.album.name
+                            )));
+
+                            m.insert("xesam:artist".to_string(), Variant(Box::new(
+                                track.artists
+                                    .iter()
+                                    .map(|a| a.name.to_string())
+                                    .collect::<Vec<_>>()
+                            )));
+
+                            m.insert("xesam:albumArtist".to_string(), Variant(Box::new(
+                                track.album.artists
+                                    .iter()
+                                    .map(|a| a.name.to_string())
+                                    .collect::<Vec<_>>()
+                            )));
+
+                            m.insert("xesam:autoRating".to_string(), Variant(Box::new(
+                                (f64::from(track.popularity) / 100.0) as f64
+                            )));
+
+                            m.insert("xesam:trackNumber".to_string(), Variant(Box::new(
+                                track.track_number
+                            )));
+
+                            m.insert("xesam:discNumber".to_string(), Variant(Box::new(
+                                track.disc_number
+                            )));
+
+                            m.insert("xesam:url".to_string(), Variant(Box::new(
+                                track.external_urls
+                                    .iter()
+                                    .next()
+                                    .map_or("", |(_, v)| &v)
+                                    .to_string()
+                            )));
+                        }
+                    } else {
+                        info!("Couldn't fetch metadata from spotify: {:?}", v);
+                    }
+
+                    Ok(m)
+                });
+
+            for prop in vec!["CanPlay", "CanPause", "CanSeek", "CanControl", "CanGoPrevious", "CanGoNext"] {
+                b.property(prop).emits_changed_const().get(|_, _| Ok(true));
             }
-        ));
-
-    let property_rate = f
-        .property::<f64, _>("Rate", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(1.0);
-            Ok(())
         });
 
-    let property_volume = f
-        .property::<f64, _>("Volume", ())
-        .access(Access::Read)
-        .on_get(spotify_api_property!([sp, _device]
-            if let Ok(Some(player)) = sp.current_playback(None) {
-                player.device.volume_percent as f64
-            } else {
-                0.0
-            }
-        ));
+    cr.insert("/", &[media_player2_interface, player_interface], ());
 
-    let property_max_rate = f
-        .property::<f64, _>("MaximumRate", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(1.0);
-            Ok(())
-        });
+    conn.start_receive(MatchRule::new_method_call(), Box::new( move |msg, conn| {
+        cr.handle_message(msg, conn).unwrap();
+        true
+    }));
 
-    let property_min_rate = f
-        .property::<f64, _>("MinimumRate", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(1.0);
-            Ok(())
-        });
-
-    let property_loop_status = f
-        .property::<String, _>("LoopStatus", ())
-        .access(Access::Read)
-        .on_get(spotify_api_property!([sp, _device]
-            if let Ok(Some(player)) = sp.current_playback(None) {
-                match player.repeat_state {
-                    RepeatState::Off => "None",
-                    RepeatState::Track => "Track",
-                    RepeatState::Context => "Playlist",
-                }
-            } else {
-                "None"
-            }.to_string()
-        ));
-
-    let property_position = f
-        .property::<i64, _>("Position", ())
-        .access(Access::Read)
-        .on_get(spotify_api_property!([sp, _device]
-            if let Ok(Some(pos)) =
-                sp.current_playback(None)
-                .map(|maybe_player| maybe_player.and_then(|p| p.progress_ms)) {
-                i64::from(pos) * 1000
-            } else {
-                0
-            }
-        ));
-
-    let property_metadata = f
-        .property::<HashMap<String, Variant<Box<dyn RefArg>>>, _>("Metadata", ())
-        .access(Access::Read)
-        .on_get(spotify_api_property!([sp, _device] {
-            let mut m = HashMap::new();
-            let v = sp.current_user_playing_track();
-
-            if let Ok(Some(playing)) = v {
-                if let Some(track) = playing.item {
-                    m.insert("mpris:trackid".to_string(), Variant(Box::new(
-                        MessageItem::Str(
-                            track.uri
-                        )) as Box<dyn RefArg>));
-
-                    m.insert("mpris:length".to_string(), Variant(Box::new(
-                        MessageItem::Int64(
-                            i64::from(track.duration_ms) * 1000
-                        )) as Box<dyn RefArg>));
-
-                    m.insert("mpris:artUrl".to_string(), Variant(Box::new(
-                        MessageItem::Str(
-                            track.album.images
-                                .first()
-                                .unwrap().url.clone()
-                        )) as Box<dyn RefArg>));
-
-                    m.insert("xesam:title".to_string(), Variant(Box::new(
-                        MessageItem::Str(
-                            track.name
-                        )) as Box<dyn RefArg>));
-
-                    m.insert("xesam:album".to_string(), Variant(Box::new(
-                        MessageItem::Str(
-                            track.album.name
-                        )) as Box<dyn RefArg>));
-
-                    m.insert("xesam:artist".to_string(), Variant(Box::new(
-                        MessageItem::Array(MessageItemArray::new(
-                            track.artists
-                                .iter()
-                                .map(|a| MessageItem::Str(a.name.to_string()))
-                                .collect::<Vec<_>>(), Signature::new("as").unwrap()
-                        ).unwrap())) as Box<dyn RefArg>));
-
-                    m.insert("xesam:albumArtist".to_string(), Variant(Box::new(
-                        MessageItem::Array(MessageItemArray::new(
-                            track.album.artists
-                                .iter()
-                                .map(|a| MessageItem::Str(a.name.to_string()))
-                                .collect::<Vec<_>>(), Signature::new("as").unwrap()
-                        ).unwrap())) as Box<dyn RefArg>));
-
-                    m.insert("xesam:autoRating".to_string(), Variant(Box::new(
-                        MessageItem::Double(
-                            f64::from(track.popularity) / 100.0
-                        )) as Box<dyn RefArg>));
-
-                    m.insert("xesam:trackNumber".to_string(), Variant(Box::new(
-                        MessageItem::UInt32(
-                            track.track_number
-                        )) as Box<dyn RefArg>));
-
-                    m.insert("xesam:discNumber".to_string(), Variant(Box::new(
-                        MessageItem::Int32(
-                            track.disc_number
-                        )) as Box<dyn RefArg>));
-
-                    m.insert("xesam:url".to_string(), Variant(Box::new(
-                        MessageItem::Str(
-                            track.external_urls
-                                .iter()
-                                .next()
-                                .map_or("", |(_, v)| &v)
-                                .to_string()
-                        )) as Box<dyn RefArg>));
-                }
-            } else {
-                info!("Couldn't fetch metadata from spotify: {:?}", v);
-            }
-
-            m
-        }));
-
-    let property_can_play = f
-        .property::<bool, _>("CanPlay", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(true);
-            Ok(())
-        });
-
-    let property_can_pause = f
-        .property::<bool, _>("CanPause", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(true);
-            Ok(())
-        });
-
-    let property_can_seek = f
-        .property::<bool, _>("CanSeek", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(true);
-            Ok(())
-        });
-
-    let property_can_control = f
-        .property::<bool, _>("CanControl", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(true);
-            Ok(())
-        });
-
-    let property_can_go_previous = f
-        .property::<bool, _>("CanGoPrevious", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(true);
-            Ok(())
-        });
-
-    let property_can_go_next = f
-        .property::<bool, _>("CanGoNext", ())
-        .access(Access::Read)
-        .on_get(|iter, _| {
-            iter.append(true);
-            Ok(())
-        });
-
-    let media_player2_player_interface = f
-        .interface("org.mpris.MediaPlayer2.Player", ())
-        .add_m(method_volume_up)
-        .add_m(method_volume_down)
-        .add_m(method_next)
-        .add_m(method_previous)
-        .add_m(method_pause)
-        .add_m(method_play_pause)
-        .add_m(method_play)
-        .add_m(method_stop)
-        .add_m(method_seek)
-        .add_m(method_set_position)
-        .add_m(method_open_uri)
-        .add_p(property_playback_status)
-        .add_p(property_rate)
-        .add_p(property_volume)
-        .add_p(property_max_rate)
-        .add_p(property_min_rate)
-        .add_p(property_loop_status)
-        .add_p(property_position)
-        .add_p(property_metadata)
-        .add_p(property_can_play)
-        .add_p(property_can_pause)
-        .add_p(property_can_seek)
-        .add_p(property_can_control)
-        .add_p(property_can_go_next)
-        .add_p(property_can_go_previous)
-        .add_p(property_shuffle);
-
-    let tree = f.tree(ATree::new()).add(
-        f.object_path("/org/mpris/MediaPlayer2", ())
-            .introspectable()
-            .add(media_player2_interface)
-            .add(media_player2_player_interface),
-    );
-
-    tree.set_registered(&connection, true)
-        .expect("Failed to register tree");
-
-    //let handle = tokio_compat::runtime::Handle::current();
-
-    let async_connection = AConnection::new(connection.clone(), handle)
-        .expect("Failed to create async dbus connection");
-
-    let server = ATreeServer::new(
-        connection,
-        Box::new(tree),
-        async_connection
-            .messages()
-            .expect("Failed to unwrap async messages"),
-    );
-
-    Box::pin(server.for_each(|message| {
-        warn!("Unhandled DBus message: {:?}", message);
-        Ok(())
-    }))
+    // run forever
+    futures::future::pending::<()>().await;
+    unreachable!();
 }

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -1,4 +1,10 @@
 use chrono::prelude::*;
+use dbus::arg::{RefArg, Variant};
+use dbus::channel::MatchingReceiver;
+use dbus::message::MatchRule;
+use dbus_crossroads::{Crossroads, IfaceToken};
+use dbus_tokio::connection;
+use futures::task::{Context, Poll};
 use futures::{self, Future};
 use librespot::{
     connect::spirc::Spirc,
@@ -14,21 +20,15 @@ use rspotify::spotify::{
     client::Spotify, model::offset::for_position, oauth2::TokenInfo as RspotifyToken, senum::*,
     util::datetime_to_timestamp,
 };
-use std::{collections::HashMap, env};
 use std::pin::Pin;
-use futures::task::{Context, Poll};
-use dbus_tokio::connection;
 use std::sync::Arc;
-use dbus::channel::MatchingReceiver;
-use dbus::message::MatchRule;
-use dbus_crossroads::{Crossroads, IfaceToken};
-use dbus::arg::{Variant, RefArg};
+use std::{collections::HashMap, env};
 
 pub struct DbusServer {
     session: Session,
     spirc: Arc<Spirc>,
     api_token: RspotifyToken,
-    token_request: Option<Pin<Box<dyn Future<Output=Result<LibrespotToken, MercuryError>>>>>,
+    token_request: Option<Pin<Box<dyn Future<Output = Result<LibrespotToken, MercuryError>>>>>,
     dbus_future: Option<Pin<Box<dyn Future<Output = ()>>>>,
     device_name: String,
 }
@@ -42,11 +42,7 @@ const SCOPE: &str = "user-read-playback-state,user-read-private,\
                      user-read-recently-played";
 
 impl DbusServer {
-    pub fn new(
-        session: Session,
-        spirc: Arc<Spirc>,
-        device_name: String,
-    ) -> DbusServer {
+    pub fn new(session: Session, spirc: Arc<Spirc>, device_name: String) -> DbusServer {
         DbusServer {
             session,
             spirc,
@@ -90,10 +86,8 @@ impl Future for DbusServer {
                     let sess = self.session.clone();
                     // This is more meant as a fast hotfix than anything else!
                     let client_id =
-                            env::var("SPOTIFYD_CLIENT_ID").unwrap_or_else(|_| CLIENT_ID.to_string());
-                    async move {
-                        get_token(&sess, &client_id, SCOPE).await
-                    }
+                        env::var("SPOTIFYD_CLIENT_ID").unwrap_or_else(|_| CLIENT_ID.to_string());
+                    async move { get_token(&sess, &client_id, SCOPE).await }
                 }));
             }
         } else if let Some(ref mut fut) = self.dbus_future {
@@ -112,322 +106,350 @@ fn create_spotify_api(token: &RspotifyToken) -> Spotify {
     Spotify::default().access_token(&token.access_token).build()
 }
 
-async fn create_dbus_server(
-    api_token: RspotifyToken,
-    spirc: Arc<Spirc>,
-    device_name: String,
-) {
+async fn create_dbus_server(api_token: RspotifyToken, spirc: Arc<Spirc>, device_name: String) {
     // TODO: allow other DBus types through CLI and config entry.
-    let (resource, conn) = connection::new_session_sync().expect("Failed to initialize DBus connection");
+    let (resource, conn) =
+        connection::new_session_sync().expect("Failed to initialize DBus connection");
     tokio::spawn(async {
         let err = resource.await;
         panic!("Lost connection to D-Bus: {}", err);
     });
 
-    conn.request_name(
-        "org.mpris.MediaPlayer2.spotifyd",
-        false,
-        true,
-        true
-    ).await.expect("Failed to register dbus player name");
+    conn.request_name("org.mpris.MediaPlayer2.spotifyd", false, true, true)
+        .await
+        .expect("Failed to register dbus player name");
 
     let mut cr = Crossroads::new();
-    cr.set_async_support(Some((conn.clone(), Box::new(|x| { tokio::spawn(x); }))));
+    cr.set_async_support(Some((
+        conn.clone(),
+        Box::new(|x| {
+            tokio::spawn(x);
+        }),
+    )));
 
     // The following methods and properties are part of the MediaPlayer2 interface.
     // https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html
-    let media_player2_interface = cr
-        .register("org.mpris.MediaPlayer2", |b| {
-           b.method("Raise", (), (), move |_,_,():()| {
-               // noop
-               Ok(())
-           });
-            let local_spirc = spirc.clone();
-            b.method("Quit", (), (), move |_,_,():()| {
-                local_spirc.shutdown();
-                Ok(())
-            });
-            b.property("CanQuit")
-                .emits_changed_const()
-                .get(|_,_| Ok(true));
-            b.property("CanRaise")
-                .emits_changed_const()
-                .get(|_,_| Ok(false));
-            b.property("CanSetFullscreen")
-                .emits_changed_const()
-                .get(|_,_| Ok(false));
-            b.property("HasTrackList")
-                .emits_changed_const()
-                .get(|_,_| Ok(false));
-            b.property("Identity")
-                .emits_changed_const()
-                .get(|_,_| Ok("Spotifyd".to_string()));
-            b.property("SupportedUriSchemes")
-                .emits_changed_const()
-                .get(|_,_| Ok(vec!["spotify".to_string()]));
-            b.property("SupportedMimeTypes")
-                .emits_changed_const()
-                .get(|_,_| Ok(Vec::<String>::new()));
+    let media_player2_interface = cr.register("org.mpris.MediaPlayer2", |b| {
+        b.method("Raise", (), (), move |_, _, (): ()| {
+            // noop
+            Ok(())
         });
+        let local_spirc = spirc.clone();
+        b.method("Quit", (), (), move |_, _, (): ()| {
+            local_spirc.shutdown();
+            Ok(())
+        });
+        b.property("CanQuit")
+            .emits_changed_const()
+            .get(|_, _| Ok(true));
+        b.property("CanRaise")
+            .emits_changed_const()
+            .get(|_, _| Ok(false));
+        b.property("CanSetFullscreen")
+            .emits_changed_const()
+            .get(|_, _| Ok(false));
+        b.property("HasTrackList")
+            .emits_changed_const()
+            .get(|_, _| Ok(false));
+        b.property("Identity")
+            .emits_changed_const()
+            .get(|_, _| Ok("Spotifyd".to_string()));
+        b.property("SupportedUriSchemes")
+            .emits_changed_const()
+            .get(|_, _| Ok(vec!["spotify".to_string()]));
+        b.property("SupportedMimeTypes")
+            .emits_changed_const()
+            .get(|_, _| Ok(Vec::<String>::new()));
+    });
 
     // The following methods and properties are part of the MediaPlayer2.Player interface.
     // https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html
 
-    let player_interface: IfaceToken<()> = cr
-        .register("org.mpris.MediaPlayer2.Player", |b| {
-            let local_spirc = spirc.clone();
-            b.method("VolumeUp", (), (), move |_,_,():()| {
-                local_spirc.volume_up();
-                Ok(())
-            });
-            let local_spirc = spirc.clone();
-            b.method("VolumeDown", (), (), move |_,_,():()| {
-                local_spirc.volume_down();
-                Ok(())
-            });
-            let local_spirc = spirc.clone();
-            b.method("Next", (), (), move |_,_,():()| {
-                local_spirc.next();
-                Ok(())
-            });
-            let local_spirc = spirc.clone();
-            b.method("Previous", (), (), move |_,_,():()| {
-                local_spirc.prev();
-                Ok(())
-            });
-            let local_spirc = spirc.clone();
-            b.method("Pause", (), (), move |_,_,():()| {
-                local_spirc.pause();
-                Ok(())
-            });
-            let local_spirc = spirc.clone();
-            b.method("PlayPause", (), (), move |_,_,():()| {
-                local_spirc.play_pause();
-                Ok(())
-            });
-            let local_spirc = spirc.clone();
-            b.method("Play", (), (), move |_,_,():()| {
-                local_spirc.play();
-                Ok(())
-            });
-            let local_spirc = spirc.clone();
-            b.method("Stop", (), (), move |_,_,():()| {
-                // TODO: add real stop implementation.
-                local_spirc.pause();
-                Ok(())
-            });
+    let player_interface: IfaceToken<()> = cr.register("org.mpris.MediaPlayer2.Player", |b| {
+        let local_spirc = spirc.clone();
+        b.method("VolumeUp", (), (), move |_, _, (): ()| {
+            local_spirc.volume_up();
+            Ok(())
+        });
+        let local_spirc = spirc.clone();
+        b.method("VolumeDown", (), (), move |_, _, (): ()| {
+            local_spirc.volume_down();
+            Ok(())
+        });
+        let local_spirc = spirc.clone();
+        b.method("Next", (), (), move |_, _, (): ()| {
+            local_spirc.next();
+            Ok(())
+        });
+        let local_spirc = spirc.clone();
+        b.method("Previous", (), (), move |_, _, (): ()| {
+            local_spirc.prev();
+            Ok(())
+        });
+        let local_spirc = spirc.clone();
+        b.method("Pause", (), (), move |_, _, (): ()| {
+            local_spirc.pause();
+            Ok(())
+        });
+        let local_spirc = spirc.clone();
+        b.method("PlayPause", (), (), move |_, _, (): ()| {
+            local_spirc.play_pause();
+            Ok(())
+        });
+        let local_spirc = spirc.clone();
+        b.method("Play", (), (), move |_, _, (): ()| {
+            local_spirc.play();
+            Ok(())
+        });
+        let local_spirc = spirc.clone();
+        b.method("Stop", (), (), move |_, _, (): ()| {
+            // TODO: add real stop implementation.
+            local_spirc.pause();
+            Ok(())
+        });
 
-            let mv_device_name = device_name.clone();
-            let mv_api_token = api_token.clone();
-            b.method("Seek", ("pos",), (), move |_,_,(pos,):(u32,)| {
-                let device_name = utf8_percent_encode(&mv_device_name, NON_ALPHANUMERIC).to_string();
-                let sp = create_spotify_api(&mv_api_token);
-                if let Ok(Some(playing)) = sp.current_user_playing_track() {
-                    let _ = sp.seek_track(playing.progress_ms.unwrap_or(0) + pos, Some(device_name));
+        let mv_device_name = device_name.clone();
+        let mv_api_token = api_token.clone();
+        b.method("Seek", ("pos",), (), move |_, _, (pos,): (u32,)| {
+            let device_name = utf8_percent_encode(&mv_device_name, NON_ALPHANUMERIC).to_string();
+            let sp = create_spotify_api(&mv_api_token);
+            if let Ok(Some(playing)) = sp.current_user_playing_track() {
+                let _ = sp.seek_track(playing.progress_ms.unwrap_or(0) + pos, Some(device_name));
+            }
+            Ok(())
+        });
+
+        let mv_device_name = device_name.clone();
+        let mv_api_token = api_token.clone();
+        b.method("SetPosition", ("pos",), (), move |_, _, (pos,): (u32,)| {
+            let device_name = utf8_percent_encode(&mv_device_name, NON_ALPHANUMERIC).to_string();
+            let sp = create_spotify_api(&mv_api_token);
+            let _ = sp.seek_track(pos, Some(device_name));
+            Ok(())
+        });
+
+        let mv_device_name = device_name.clone();
+        let mv_api_token = api_token.clone();
+        b.method("OpenUri", ("uri",), (), move |_, _, (uri,): (String,)| {
+            let device_name = utf8_percent_encode(&mv_device_name, NON_ALPHANUMERIC).to_string();
+            let sp = create_spotify_api(&mv_api_token);
+            let device_id = match sp.device() {
+                Ok(device_payload) => {
+                    match device_payload
+                        .devices
+                        .into_iter()
+                        .find(|d| d.is_active && d.name == device_name)
+                    {
+                        Some(device) => Some(device.id),
+                        None => None,
+                    }
                 }
-                Ok(())
-            });
+                Err(_) => None,
+            };
 
-            let mv_device_name = device_name.clone();
-            let mv_api_token = api_token.clone();
-            b.method("SetPosition", ("pos",), (), move |_,_,(pos,):(u32,)| {
-                let device_name = utf8_percent_encode(&mv_device_name, NON_ALPHANUMERIC).to_string();
+            if uri.contains("spotify:track") {
+                let _ = sp.start_playback(device_id, None, Some(vec![uri]), for_position(0), None);
+            } else {
+                let _ = sp.start_playback(device_id, Some(uri), None, for_position(0), None);
+            }
+            Ok(())
+        });
+
+        let mv_device_name = device_name.clone();
+        let mv_api_token = api_token.clone();
+        b.property("PlaybackStatus")
+            .emits_changed_false()
+            .get(move |_, _| {
                 let sp = create_spotify_api(&mv_api_token);
-                let _ = sp.seek_track(pos, Some(device_name));
-                Ok(())
-            });
-
-            let mv_device_name = device_name.clone();
-            let mv_api_token = api_token.clone();
-            b.method("OpenUri", ("uri",), (), move |_,_,(uri,):(String,)| {
-                let device_name = utf8_percent_encode(&mv_device_name, NON_ALPHANUMERIC).to_string();
-                let sp = create_spotify_api(&mv_api_token);
-                let device_id = match sp.device() {
-                    Ok(device_payload) => {
-                        match device_payload.devices.into_iter().find(|d| d.is_active && d.name == device_name) {
-                            Some(device) => Some(device.id),
-                            None => None,
-                        }
-                    },
-                    Err(_) => None,
-                };
-
-                if uri.contains("spotify:track") {
-                    let _ = sp.start_playback(device_id, None, Some(vec![uri]), for_position(0), None);
-                } else {
-                    let _ = sp.start_playback(device_id, Some(uri), None, for_position(0), None);
-                }
-                Ok(())
-            });
-
-            let mv_device_name = device_name.clone();
-            let mv_api_token = api_token.clone();
-            b.property("PlaybackStatus")
-                .emits_changed_false()
-                .get(move |_,_| {
-                    let sp = create_spotify_api(&mv_api_token);
-                    if let Ok(Some(player)) = sp.current_playback(None) {
-                        if player.device.name == mv_device_name {
-                            if let Ok(Some(track)) = sp.current_user_playing_track() {
-                                if track.is_playing {
-                                    return Ok("Playing".to_string())
-                                } else {
-                                    return Ok("Paused".to_string())
-                                }
+                if let Ok(Some(player)) = sp.current_playback(None) {
+                    if player.device.name == mv_device_name {
+                        if let Ok(Some(track)) = sp.current_user_playing_track() {
+                            if track.is_playing {
+                                return Ok("Playing".to_string());
+                            } else {
+                                return Ok("Paused".to_string());
                             }
                         }
                     }
-                    Ok("Stopped".to_string())
-                });
+                }
+                Ok("Stopped".to_string())
+            });
 
-            let mv_api_token = api_token.clone();
-            b.property("Shuffle")
-                .emits_changed_false()
-                .get(move |_,_| {
-                    let sp = create_spotify_api(&mv_api_token);
-                    let shuffle_status = sp.current_playback(None).ok().flatten().map_or(false, |p| p.shuffle_state);
-                    Ok(shuffle_status)
-                });
+        let mv_api_token = api_token.clone();
+        b.property("Shuffle")
+            .emits_changed_false()
+            .get(move |_, _| {
+                let sp = create_spotify_api(&mv_api_token);
+                let shuffle_status = sp
+                    .current_playback(None)
+                    .ok()
+                    .flatten()
+                    .map_or(false, |p| p.shuffle_state);
+                Ok(shuffle_status)
+            });
 
-            b.property("Rate")
-                .emits_changed_const()
-                .get(|_,_| {
-                    Ok(1.0)
-                });
+        b.property("Rate").emits_changed_const().get(|_, _| Ok(1.0));
 
-            let mv_api_token = api_token.clone();
-            b.property("Volume")
-                .emits_changed_false()
-                .get(move |_,_| {
-                    let sp = create_spotify_api(&mv_api_token);
-                    let vol = sp.current_playback(None).ok().flatten().map_or(0.0, |p| p.device.volume_percent as f64);
-                    Ok(vol)
-                });
+        let mv_api_token = api_token.clone();
+        b.property("Volume").emits_changed_false().get(move |_, _| {
+            let sp = create_spotify_api(&mv_api_token);
+            let vol = sp
+                .current_playback(None)
+                .ok()
+                .flatten()
+                .map_or(0.0, |p| p.device.volume_percent as f64);
+            Ok(vol)
+        });
 
-            b.property("MaximumRate")
-                .emits_changed_const()
-                .get(|_,_| {
-                    Ok(1.0)
-                });
-            b.property("MinimumRate")
-                .emits_changed_const()
-                .get(|_,_| {
-                    Ok(1.0)
-                });
+        b.property("MaximumRate")
+            .emits_changed_const()
+            .get(|_, _| Ok(1.0));
+        b.property("MinimumRate")
+            .emits_changed_const()
+            .get(|_, _| Ok(1.0));
 
-            let mv_api_token = api_token.clone();
-            b.property("LoopStatus")
-                .emits_changed_false()
-                .get(move |_,_| {
-                    let sp = create_spotify_api(&mv_api_token);
-                    let status = if let Ok(Some(player)) = sp.current_playback(None) {
-                        match player.repeat_state {
-                            RepeatState::Off => "None",
-                            RepeatState::Track => "Track",
-                            RepeatState::Context => "Playlist",
-                        }
-                    } else {
-                        "None"
-                    }.to_string();
-                    Ok(status)
-                });
+        let mv_api_token = api_token.clone();
+        b.property("LoopStatus")
+            .emits_changed_false()
+            .get(move |_, _| {
+                let sp = create_spotify_api(&mv_api_token);
+                let status = if let Ok(Some(player)) = sp.current_playback(None) {
+                    match player.repeat_state {
+                        RepeatState::Off => "None",
+                        RepeatState::Track => "Track",
+                        RepeatState::Context => "Playlist",
+                    }
+                } else {
+                    "None"
+                }
+                .to_string();
+                Ok(status)
+            });
 
-            let mv_api_token = api_token.clone();
-            b.property("Position")
-                .emits_changed_false()
-                .get(move |_,_| {
-                    let sp = create_spotify_api(&mv_api_token);
-                    let val = if let Ok(Some(pos)) =
-                    sp.current_playback(None)
-                        .map(|maybe_player| maybe_player.and_then(|p| p.progress_ms)) {
-                        i64::from(pos) * 1000
-                    } else {
-                        0
-                    };
-                    Ok(val)
-                });
+        let mv_api_token = api_token.clone();
+        b.property("Position")
+            .emits_changed_false()
+            .get(move |_, _| {
+                let sp = create_spotify_api(&mv_api_token);
+                let val = if let Ok(Some(pos)) = sp
+                    .current_playback(None)
+                    .map(|maybe_player| maybe_player.and_then(|p| p.progress_ms))
+                {
+                    i64::from(pos) * 1000
+                } else {
+                    0
+                };
+                Ok(val)
+            });
 
-            let mv_api_token = api_token.clone();
-            b.property("Metadata")
-                .emits_changed_false()
-                .get(move |_, _| {
-                    let sp = create_spotify_api(&mv_api_token);
+        let mv_api_token = api_token.clone();
+        b.property("Metadata")
+            .emits_changed_false()
+            .get(move |_, _| {
+                let sp = create_spotify_api(&mv_api_token);
 
-                    let mut m: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
-                    let v = sp.current_user_playing_track();
+                let mut m: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+                let v = sp.current_user_playing_track();
 
-                    if let Ok(Some(playing)) = v {
-                        if let Some(track) = playing.item {
-                            m.insert("mpris:trackid".to_string(), Variant(Box::new(track.uri)));
+                if let Ok(Some(playing)) = v {
+                    if let Some(track) = playing.item {
+                        m.insert("mpris:trackid".to_string(), Variant(Box::new(track.uri)));
 
-                            m.insert("mpris:length".to_string(), Variant(Box::new(i64::from(track.duration_ms) * 1000)));
+                        m.insert(
+                            "mpris:length".to_string(),
+                            Variant(Box::new(i64::from(track.duration_ms) * 1000)),
+                        );
 
-                            m.insert("mpris:artUrl".to_string(), Variant(Box::new(
-                                track.album.images
-                                    .first()
-                                    .unwrap().url.clone()
-                            )));
+                        m.insert(
+                            "mpris:artUrl".to_string(),
+                            Variant(Box::new(track.album.images.first().unwrap().url.clone())),
+                        );
 
-                            m.insert("xesam:title".to_string(), Variant(Box::new(
-                                track.name
-                            )));
+                        m.insert("xesam:title".to_string(), Variant(Box::new(track.name)));
 
-                            m.insert("xesam:album".to_string(), Variant(Box::new(
-                                track.album.name
-                            )));
+                        m.insert(
+                            "xesam:album".to_string(),
+                            Variant(Box::new(track.album.name)),
+                        );
 
-                            m.insert("xesam:artist".to_string(), Variant(Box::new(
-                                track.artists
+                        m.insert(
+                            "xesam:artist".to_string(),
+                            Variant(Box::new(
+                                track
+                                    .artists
                                     .iter()
                                     .map(|a| a.name.to_string())
-                                    .collect::<Vec<_>>()
-                            )));
+                                    .collect::<Vec<_>>(),
+                            )),
+                        );
 
-                            m.insert("xesam:albumArtist".to_string(), Variant(Box::new(
-                                track.album.artists
+                        m.insert(
+                            "xesam:albumArtist".to_string(),
+                            Variant(Box::new(
+                                track
+                                    .album
+                                    .artists
                                     .iter()
                                     .map(|a| a.name.to_string())
-                                    .collect::<Vec<_>>()
-                            )));
+                                    .collect::<Vec<_>>(),
+                            )),
+                        );
 
-                            m.insert("xesam:autoRating".to_string(), Variant(Box::new(
-                                (f64::from(track.popularity) / 100.0) as f64
-                            )));
+                        m.insert(
+                            "xesam:autoRating".to_string(),
+                            Variant(Box::new((f64::from(track.popularity) / 100.0) as f64)),
+                        );
 
-                            m.insert("xesam:trackNumber".to_string(), Variant(Box::new(
-                                track.track_number
-                            )));
+                        m.insert(
+                            "xesam:trackNumber".to_string(),
+                            Variant(Box::new(track.track_number)),
+                        );
 
-                            m.insert("xesam:discNumber".to_string(), Variant(Box::new(
-                                track.disc_number
-                            )));
+                        m.insert(
+                            "xesam:discNumber".to_string(),
+                            Variant(Box::new(track.disc_number)),
+                        );
 
-                            m.insert("xesam:url".to_string(), Variant(Box::new(
-                                track.external_urls
+                        m.insert(
+                            "xesam:url".to_string(),
+                            Variant(Box::new(
+                                track
+                                    .external_urls
                                     .iter()
                                     .next()
                                     .map_or("", |(_, v)| &v)
-                                    .to_string()
-                            )));
-                        }
-                    } else {
-                        info!("Couldn't fetch metadata from spotify: {:?}", v);
+                                    .to_string(),
+                            )),
+                        );
                     }
+                } else {
+                    info!("Couldn't fetch metadata from spotify: {:?}", v);
+                }
 
-                    Ok(m)
-                });
+                Ok(m)
+            });
 
-            for prop in vec!["CanPlay", "CanPause", "CanSeek", "CanControl", "CanGoPrevious", "CanGoNext"] {
-                b.property(prop).emits_changed_const().get(|_, _| Ok(true));
-            }
-        });
+        for prop in vec![
+            "CanPlay",
+            "CanPause",
+            "CanSeek",
+            "CanControl",
+            "CanGoPrevious",
+            "CanGoNext",
+        ] {
+            b.property(prop).emits_changed_const().get(|_, _| Ok(true));
+        }
+    });
 
     cr.insert("/", &[media_player2_interface, player_interface], ());
 
-    conn.start_receive(MatchRule::new_method_call(), Box::new( move |msg, conn| {
-        cr.handle_message(msg, conn).unwrap();
-        true
-    }));
+    conn.start_receive(
+        MatchRule::new_method_call(),
+        Box::new(move |msg, conn| {
+            cr.handle_message(msg, conn).unwrap();
+            true
+        }),
+    );
 
     // run forever
     futures::future::pending::<()>().await;

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -444,7 +444,11 @@ async fn create_dbus_server(api_token: RspotifyToken, spirc: Arc<Spirc>, device_
         }
     });
 
-    cr.insert("/org/mpris/MediaPlayer2", &[media_player2_interface, player_interface], ());
+    cr.insert(
+        "/org/mpris/MediaPlayer2",
+        &[media_player2_interface, player_interface],
+        (),
+    );
 
     conn.start_receive(
         MatchRule::new_method_call(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ fn main() -> Result<(), Report> {
 
     let runtime = Runtime::new().unwrap();
     runtime.block_on(async {
-       let initial_state = setup::initial_state(internal_config);
+        let initial_state = setup::initial_state(internal_config);
         initial_state.await;
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use daemonize::Daemonize;
 use log::{error, info, trace, LevelFilter};
 use std::panic;
 use structopt::StructOpt;
-use tokio_core::reactor::Core;
+use tokio::runtime::Runtime;
 
 #[cfg(feature = "alsa_backend")]
 mod alsa_mixer;
@@ -104,11 +104,11 @@ fn main() -> Result<(), Report> {
         );
     }));
 
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
-
-    let initial_state = setup::initial_state(handle, internal_config);
-    core.run(initial_state).unwrap();
+    let runtime = Runtime::new().unwrap();
+    runtime.block_on(async {
+       let initial_state = setup::initial_state(internal_config);
+        initial_state.await;
+    });
 
     Ok(())
 }

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -143,7 +143,6 @@ impl Future for MainLoopState {
             }
 
             if let Some(ref mut fut) = self.spotifyd_state.dbus_mpris_server {
-                // TODO: original PR says let _ = Future::poll(fut.as_mut(), cx);
                 let _ = fut.as_mut().poll(cx);
             }
 
@@ -195,7 +194,6 @@ impl Future for MainLoopState {
                         spirc.shutdown();
                         self.spotifyd_state.shutting_down = true;
                     }
-                    // TODO: have I accidentally short-circuited the shutdown logic here?
                     return Poll::Ready(());
                 }
             } else if let Some(Poll::Ready(_)) = self

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -2,21 +2,19 @@
 use crate::dbus_mpris::DbusServer;
 use crate::process::{spawn_program_on_event, Child};
 use futures::{self, Future, Stream, StreamExt};
-use librespot::core::session::SessionError;
-use librespot::playback::config::AudioFormat;
-use librespot::{
-    connect::{discovery::DiscoveryStream, spirc::Spirc},
-    core::{
-        cache::Cache,
-        config::{ConnectConfig, DeviceType, SessionConfig, VolumeCtrl},
-        session::Session,
-    },
-    playback::{
-        audio_backend::Sink,
-        config::PlayerConfig,
-        mixer::Mixer,
-        player::{Player, PlayerEvent},
-    },
+use librespot_connect::{discovery::DiscoveryStream, spirc::Spirc};
+use librespot_core::session::SessionError;
+use librespot_core::{
+    cache::Cache,
+    config::{ConnectConfig, DeviceType, SessionConfig, VolumeCtrl},
+    session::Session,
+};
+use librespot_playback::config::AudioFormat;
+use librespot_playback::{
+    audio_backend::Sink,
+    config::PlayerConfig,
+    mixer::Mixer,
+    player::{Player, PlayerEvent},
 };
 use log::error;
 use std::io;

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1,11 +1,11 @@
 #[cfg(feature = "dbus_mpris")]
 use crate::dbus_mpris::DbusServer;
 use crate::process::{spawn_program_on_event, Child};
-use futures::{self, Async, Future, Poll, Stream};
+use futures::{self, Future, StreamExt, Stream};
 use librespot::{
     connect::{
         discovery::DiscoveryStream,
-        spirc::{Spirc, SpircTask},
+        spirc::{Spirc},
     },
     core::{
         cache::Cache,
@@ -21,19 +21,22 @@ use librespot::{
 };
 use log::error;
 use std::{io, rc::Rc};
-use tokio_core::reactor::Handle;
-use tokio_io::IoStream;
+use librespot::core::session::SessionError;
+use std::pin::Pin;
+use librespot::playback::config::AudioFormat;
+use std::task::{Context, Poll};
+use tokio_stream::wrappers::UnboundedReceiverStream;
 
 pub struct LibreSpotConnection {
-    connection: Box<dyn Future<Item = Session, Error = io::Error>>,
-    spirc_task: Option<SpircTask>,
+    connection: Pin<Box<dyn Future<Output=Result<Session, SessionError>>>>,
+    spirc_task: Option<Pin<Box<dyn Future<Output=()>>>>,
     spirc: Option<Rc<Spirc>>,
     discovery_stream: DiscoveryStream,
 }
 
 impl LibreSpotConnection {
     pub fn new(
-        connection: Box<dyn Future<Item = Session, Error = io::Error>>,
+        connection: Pin<Box<dyn Future<Output=Result<Session, SessionError>>>>,
         discovery_stream: DiscoveryStream,
     ) -> LibreSpotConnection {
         LibreSpotConnection {
@@ -47,31 +50,30 @@ impl LibreSpotConnection {
 
 pub struct AudioSetup {
     pub mixer: Box<dyn FnMut() -> Box<dyn Mixer>>,
-    pub backend: fn(Option<String>) -> Box<dyn Sink>,
+    pub backend: fn(Option<String>, AudioFormat) -> Box<dyn Sink>,
     pub audio_device: Option<String>,
 }
 
 pub struct SpotifydState {
-    pub ctrl_c_stream: IoStream<()>,
+    // TODO: this ain't a stream anymore, rename
+    pub ctrl_c_stream: Pin<Box<dyn Future<Output=Result<(),io::Error>>>>,
     pub shutting_down: bool,
     pub cache: Option<Cache>,
     pub device_name: String,
-    pub player_event_channel: Option<futures::sync::mpsc::UnboundedReceiver<PlayerEvent>>,
+    pub player_event_channel: Option<Pin<Box<dyn Stream<Item=PlayerEvent>>>>,
     pub player_event_program: Option<String>,
-    pub dbus_mpris_server: Option<Box<dyn Future<Item = (), Error = ()>>>,
+    pub dbus_mpris_server: Option<Pin<Box<dyn Future<Output=()>>>>,
 }
 
 #[cfg(feature = "dbus_mpris")]
 #[allow(clippy::unnecessary_wraps)]
 fn new_dbus_server(
     session: Session,
-    handle: Handle,
     spirc: Rc<Spirc>,
     device_name: String,
-) -> Option<Box<dyn Future<Item = (), Error = ()>>> {
-    Some(Box::new(DbusServer::new(
+) -> Option<Pin<Box<dyn Future<Output=()>>>> {
+    Some(Box::pin(DbusServer::new(
         session,
-        handle,
         spirc,
         device_name,
     )))
@@ -80,10 +82,9 @@ fn new_dbus_server(
 #[cfg(not(feature = "dbus_mpris"))]
 fn new_dbus_server(
     _: Session,
-    _: Handle,
     _: Rc<Spirc>,
     _: String,
-) -> Option<Box<dyn Future<Item = (), Error = ()>>> {
+)  -> Option<Pin<Box<dyn Future<Output=()>>>> {
     None
 }
 
@@ -93,7 +94,6 @@ pub(crate) struct MainLoopState {
     pub(crate) spotifyd_state: SpotifydState,
     pub(crate) player_config: PlayerConfig,
     pub(crate) session_config: SessionConfig,
-    pub(crate) handle: Handle,
     pub(crate) autoplay: bool,
     pub(crate) volume_ctrl: VolumeCtrl,
     pub(crate) initial_volume: Option<u16>,
@@ -104,22 +104,21 @@ pub(crate) struct MainLoopState {
 }
 
 impl Future for MainLoopState {
-    type Error = ();
-    type Item = ();
+    type Output = ();
 
-    fn poll(&mut self) -> Poll<(), ()> {
+    fn poll(mut self: Pin<&mut MainLoopState>, cx: &mut Context<'_>) -> Poll<()> {
         loop {
-            if let Async::Ready(Some(creds)) =
-                self.librespot_connection.discovery_stream.poll().unwrap()
+            if let Poll::Ready(Some(creds)) =
+                self.as_mut().librespot_connection.discovery_stream.poll_next_unpin(cx)
             {
                 if let Some(ref mut spirc) = self.librespot_connection.spirc {
                     spirc.shutdown();
                 }
                 let session_config = self.session_config.clone();
                 let cache = self.spotifyd_state.cache.clone();
-                let handle = self.handle.clone();
+                // TODO: a bunch of this init logic can probably be unrolled using async / await
                 self.librespot_connection.connection =
-                    Session::connect(session_config, creds, cache, handle);
+                    Box::pin(Session::connect(session_config, creds, cache));
             }
 
             if let Some(mut child) = self.running_event_program.take() {
@@ -135,7 +134,7 @@ impl Future for MainLoopState {
             if self.running_event_program.is_none() {
                 if let Some(ref mut player_event_channel) = self.spotifyd_state.player_event_channel
                 {
-                    if let Async::Ready(Some(event)) = player_event_channel.poll().unwrap() {
+                    if let Poll::Ready(Some(event)) = player_event_channel.poll_next_unpin(cx) {
                         if let Some(ref cmd) = self.spotifyd_state.player_event_program {
                             match spawn_program_on_event(&self.shell, cmd, event) {
                                 Ok(child) => self.running_event_program = Some(child),
@@ -147,23 +146,26 @@ impl Future for MainLoopState {
             }
 
             if let Some(ref mut fut) = self.spotifyd_state.dbus_mpris_server {
-                let _ = fut.poll();
+                // TODO: original PR says let _ = Future::poll(fut.as_mut(), cx);
+                let _ = fut.as_mut().poll(cx);
             }
 
-            if let Async::Ready(session) = self.librespot_connection.connection.poll().unwrap() {
+            if let Poll::Ready(Ok(session)) = self.librespot_connection.connection.as_mut().poll(cx) {
                 let mixer = (self.audio_setup.mixer)();
                 let audio_filter = mixer.get_audio_filter();
-                self.librespot_connection.connection = Box::new(futures::future::empty());
+                self.librespot_connection.connection = Box::pin(futures::future::pending());
                 let backend = self.audio_setup.backend;
                 let audio_device = self.audio_setup.audio_device.clone();
                 let (player, event_channel) = Player::new(
                     self.player_config.clone(),
                     session.clone(),
                     audio_filter,
-                    move || (backend)(audio_device),
+                    // TODO: dunno how to work with AudioFormat yet, maybe dig further if this
+                    // doesn't work for all configurations
+                    move || (backend)(audio_device, AudioFormat::default()),
                 );
 
-                self.spotifyd_state.player_event_channel = Some(event_channel);
+                self.spotifyd_state.player_event_channel = Some(Box::pin(UnboundedReceiverStream::new(event_channel)));
 
                 let (spirc, spirc_task) = Spirc::new(
                     ConnectConfig {
@@ -177,36 +179,35 @@ impl Future for MainLoopState {
                     player,
                     mixer,
                 );
-                self.librespot_connection.spirc_task = Some(spirc_task);
+                self.librespot_connection.spirc_task = Some(Box::pin(spirc_task));
                 let shared_spirc = Rc::new(spirc);
                 self.librespot_connection.spirc = Some(shared_spirc.clone());
 
                 if self.use_mpris {
                     self.spotifyd_state.dbus_mpris_server = new_dbus_server(
                         session,
-                        self.handle.clone(),
                         shared_spirc,
                         self.spotifyd_state.device_name.clone(),
                     );
                 }
-            } else if let Async::Ready(_) = self.spotifyd_state.ctrl_c_stream.poll().unwrap() {
+            } else if let Poll::Ready(_) = self.spotifyd_state.ctrl_c_stream.as_mut().poll(cx) {
                 if !self.spotifyd_state.shutting_down {
                     if let Some(ref spirc) = self.librespot_connection.spirc {
                         spirc.shutdown();
                         self.spotifyd_state.shutting_down = true;
-                    } else {
-                        return Ok(Async::Ready(()));
                     }
+                    // TODO: have I accidentally short-circuited the shutdown logic here?
+                    return Poll::Ready(())
                 }
-            } else if let Some(Async::Ready(_)) = self
+            } else if let Some(Poll::Ready(_)) = self
                 .librespot_connection
                 .spirc_task
                 .as_mut()
-                .map(|ref mut st| st.poll().unwrap())
+                .map(|ref mut st| st.as_mut().poll(cx))
             {
-                return Ok(Async::Ready(()));
+                return Poll::Ready(());
             } else {
-                return Ok(Async::NotReady);
+                return Poll::Pending;
             }
         }
     }

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -186,7 +186,13 @@ impl Future for MainLoopState {
                         self.spotifyd_state.device_name.clone(),
                     );
                 }
-            } else if let Poll::Ready(_) = self.spotifyd_state.ctrl_c_stream.as_mut().poll(cx) {
+            } else if self
+                .spotifyd_state
+                .ctrl_c_stream
+                .as_mut()
+                .poll(cx)
+                .is_ready()
+            {
                 if !self.spotifyd_state.shutting_down {
                     if let Some(ref spirc) = self.librespot_connection.spirc {
                         spirc.shutdown();

--- a/src/process.rs
+++ b/src/process.rs
@@ -142,6 +142,10 @@ pub(crate) fn spawn_program_on_event(
             env.insert("TRACK_ID", track_id.to_base62());
             env.insert("PLAY_REQUEST_ID", play_request_id.to_string());
         }
+        PlayerEvent::Preloading { track_id } => {
+            env.insert("PLAYER_EVENT", "preloading".to_string());
+            env.insert("TRACK_ID", track_id.to_base62());
+        }
     }
     spawn_program(shell, cmd, env)
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use librespot::playback::player::PlayerEvent;
+use librespot_playback::player::PlayerEvent;
 use log::info;
 use std::{
     collections::HashMap,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -4,20 +4,18 @@ use crate::{config, main_loop};
 use futures;
 #[cfg(feature = "dbus_keyring")]
 use keyring::Keyring;
-use librespot::core::authentication::Credentials;
-use librespot::core::session::SessionError;
-use librespot::playback::config::AudioFormat;
-use librespot::{
-    connect::discovery::discovery,
-    core::{
-        cache::Cache,
-        config::{ConnectConfig, DeviceType, VolumeCtrl},
-        session::Session,
-    },
-    playback::{
-        audio_backend::{Sink, BACKENDS},
-        mixer::{self, Mixer},
-    },
+use librespot_connect::discovery::discovery;
+use librespot_core::{
+    authentication::Credentials,
+    cache::Cache,
+    config::{ConnectConfig, DeviceType, VolumeCtrl},
+    session::Session,
+    session::SessionError,
+};
+use librespot_playback::{
+    config::AudioFormat,
+    audio_backend::{Sink, BACKENDS},
+    mixer::{self, Mixer},
 };
 use log::info;
 use std::pin::Pin;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -13,8 +13,8 @@ use librespot_core::{
     session::SessionError,
 };
 use librespot_playback::{
-    config::AudioFormat,
     audio_backend::{Sink, BACKENDS},
+    config::AudioFormat,
     mixer::{self, Mixer},
 };
 use log::info;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,13 +1,12 @@
 #[cfg(feature = "alsa_backend")]
 use crate::alsa_mixer;
 use crate::{config, main_loop};
-use futures::{self, Future};
+use futures;
 #[cfg(feature = "dbus_keyring")]
 use keyring::Keyring;
 use librespot::{
     connect::discovery::discovery,
     core::{
-        authentication::get_credentials,
         cache::Cache,
         config::{ConnectConfig, DeviceType, VolumeCtrl},
         session::Session,
@@ -17,14 +16,15 @@ use librespot::{
         mixer::{self, Mixer},
     },
 };
-use log::{error, info};
+use log::info;
 use std::str::FromStr;
-use std::{io, process::exit};
-use tokio_core::reactor::Handle;
-use tokio_signal::ctrl_c;
+use tokio::signal::ctrl_c;
+use librespot::core::authentication::Credentials;
+use librespot::playback::config::AudioFormat;
+use librespot::core::session::SessionError;
+use std::pin::Pin;
 
 pub(crate) fn initial_state(
-    handle: Handle,
     config: config::SpotifydConfig,
 ) -> main_loop::MainLoopState {
     #[cfg(feature = "alsa_backend")]
@@ -91,7 +91,6 @@ pub(crate) fn initial_state(
 
     #[allow(clippy::or_fun_call)]
     let discovery_stream = discovery(
-        &handle,
         ConnectConfig {
             autoplay,
             name: config.device_name.clone(),
@@ -120,23 +119,17 @@ pub(crate) fn initial_state(
     }
 
     let connection = if let Some(credentials) = get_credentials(
-        username,
-        password,
-        cache.as_ref().and_then(Cache::credentials),
-        |_| {
-            error!("No password found.");
-            exit(1);
-        },
-    ) {
-        Session::connect(
+        &cache,
+        &username,
+        &password) {
+        let sess: Pin<Box<dyn futures::Future<Output=Result<Session, SessionError>>>>  = Box::pin(Session::connect(
             session_config.clone(),
             credentials,
             cache.clone(),
-            handle.clone(),
-        )
+        ));
+        sess
     } else {
-        Box::new(futures::future::empty())
-            as Box<dyn futures::Future<Item = Session, Error = io::Error>>
+        Box::pin(futures::future::pending())
     };
 
     let backend = find_backend(backend.as_ref().map(String::as_ref));
@@ -148,7 +141,7 @@ pub(crate) fn initial_state(
             audio_device: config.audio_device.clone(),
         },
         spotifyd_state: main_loop::SpotifydState {
-            ctrl_c_stream: Box::new(ctrl_c(&handle).flatten_stream()),
+            ctrl_c_stream: Box::pin(ctrl_c()),
             shutting_down: false,
             cache,
             device_name: config.device_name,
@@ -158,7 +151,6 @@ pub(crate) fn initial_state(
         },
         player_config,
         session_config,
-        handle,
         initial_volume: config.initial_volume,
         volume_ctrl,
         running_event_program: None,
@@ -169,7 +161,15 @@ pub(crate) fn initial_state(
     }
 }
 
-fn find_backend(name: Option<&str>) -> fn(Option<String>) -> Box<dyn Sink> {
+fn get_credentials(cache: &Option<Cache>, username: &Option<String>, password: &Option<String>) -> Option<Credentials> {
+    if let (Some(username), Some(password)) = (username, password) {
+        return Some(Credentials::with_password(username, password));
+    }
+
+    cache.as_ref()?.credentials()
+}
+
+fn find_backend(name: Option<&str>) -> fn(Option<String>, AudioFormat) -> Box<dyn Sink> {
     match name {
         Some(name) => {
             BACKENDS

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "alsa_backend")]
 use crate::alsa_mixer;
 use crate::{config, main_loop};
-use futures;
 #[cfg(feature = "dbus_keyring")]
 use keyring::Keyring;
 use librespot_connect::discovery::discovery;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,5 @@
 use log::trace;
 use std::env;
-#[cfg(target_os = "macos")]
-use whoami;
 
 #[cfg(any(target_os = "freebsd", target_os = "linux"))]
 fn get_shell_ffi() -> Option<String> {
@@ -97,6 +95,6 @@ mod tests {
         init_logger();
 
         let shell = get_shell_ffi();
-        assert_eq!(shell.is_some(), true);
+        assert!(shell.is_some());
     }
 }


### PR DESCRIPTION
This is an initial attempt at upgrading librespot to 0.2.0. That also required:
- upgrading tokio to 1.0
- reworking `dbus_mpris.rs` to use `dbus-crossroads`. 
 
The dbus-mpris stuff was all written using an older version of `dbus-rs`, which integrated with tokio 0.1, and therefore needed to be upgraded. I initially tried to do this with the `dbus-tree` package to minimise code changes, but I found it difficult to reason about the threading model, and eventually switched to dbus-crossroads. I hope that's ok!

I've left a number of TODOs in the code:
- some are product-ish questions (e.g. "do we want to support this new librespot feature in the spotifyd config?")
- some are places where the code works on my machine, but I'm unclear on whether it will work for everyone.

I'd love some input on how to resolve those!

Fixes https://github.com/Spotifyd/spotifyd/issues/969