### PR TITLE
fix documentation for autoplay option

### DIFF
--- a/docs/src/config/File.md
+++ b/docs/src/config/File.md
@@ -87,6 +87,9 @@ volume_normalisation = true
 # The normalisation pregain that is applied for each song.
 normalisation_pregain = -10
 
+# After the music playback has ended, start playing similar songs based on the previous tracks.
+autoplay = true
+
 # The port `spotifyd` uses to announce its service over the network.
 zeroconf_port = 1234
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -371,7 +371,7 @@ pub struct SharedConfigValues {
     #[structopt(long, possible_values = &DEVICETYPE_VALUES, value_name = "string")]
     device_type: Option<DeviceType>,
 
-    /// Autoplay on connect
+    /// Start playing similar songs after your music has ended
     #[structopt(long)]
     #[serde(default)]
     autoplay: bool,
@@ -458,6 +458,7 @@ impl fmt::Debug for SharedConfigValues {
             .field("zeroconf_port", &self.zeroconf_port)
             .field("proxy", &self.proxy)
             .field("device_type", &self.device_type)
+            .field("autoplay", &self.autoplay)
             .finish()
     }
 }
@@ -527,6 +528,7 @@ impl SharedConfigValues {
         self.use_keyring |= other.use_keyring;
         self.volume_normalisation |= other.volume_normalisation;
         self.no_audio_cache |= other.no_audio_cache;
+        self.autoplay |= other.autoplay;
     }
 }
 


### PR DESCRIPTION
Instead of the previously advertised "autoplay on connect", `autoplay` makes the playback continue after the user's selection has ended.
I also added the option to the config file and documented it there. Apparently that was all missed, when the option was initially added (2b91a0c11d01807a3220d1177008c80a8dcc2662).

For reference, see e.g. [`librespots`'s documentation](https://github.com/librespot-org/librespot/blob/c6e97a7f8ab4b7d97b82427071b2f1555557e0cc/src/main.rs#L369-L373) for that flag.

@Spotifyd/maintainers, it would be great, if someone could review this PR!

related: #1003