### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,7 +18,7 @@ parts:
   spotifyd:
     plugin: rust
     rust-channel: nightly
-    source: https://github.com/Spotifyd/spotifyd.git
+    source: .
     rust-features: ["pulseaudio_backend"]
     build-packages:
       - libssl-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: spotifyd
 adopt-info: spotifyd
 summary: A spotify daemon
+base: core18
 description: |
   An open source Spotify client running as a UNIX daemon. 
   Spotifyd streams music just like the official client, 
@@ -17,7 +18,7 @@ parts:
   spotifyd:
     plugin: rust
     rust-channel: nightly
-    source: .
+    source: https://github.com/Spotifyd/spotifyd.git
     rust-features: ["pulseaudio_backend"]
     build-packages:
       - libssl-dev
@@ -26,6 +27,7 @@ parts:
       - pkg-config
     stage-packages:
       - libpulse0
+      - libasound2
     override-pull: |
       snapcraftctl pull
       last_committed_tag="$(git describe --tags --abbrev=0)"
@@ -44,7 +46,6 @@ apps:
     environment:
       LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio"
     command: bin/spotifyd 
-    daemon: forking
     plugs:
       - network
       - network-bind


### PR DESCRIPTION
snapcraft.yaml is updated to make possible snapcraft build on Ubuntu 20.04 LTS
In scope of this PR:
* added the required dependency libasound2,
* base core specified explicitly as it is needed for the current snapcraft,
* service (daemon) is removed from snap. I think that running this daemon under superuser account (even in a confined snap) is not a best option from the security perspective. Also different PC users may require different Spotify premium credentials (like family members with different music taste) and the best place to store the credentials is user's profile or keychain, but single spotifyd system instance can't use every user's keychain with the default configuration. So the current approach of running spotifyd as a system-wide service is insecure, non-manageable and not suitable for everyone. Hereby it's better to leave such configuration on user's responsibility than introduce the insecure approach.