### PR TITLE
replace hook processes with tokio::process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0.115", features = ["derive"] }
 sha-1 = "0.9"
 structopt = "0.3.17"
 syslog = "4"
-tokio = {version = "1.6.1", features = ["signal", "rt-multi-thread"] }
+tokio = {version = "1.6.1", features = ["signal", "rt-multi-thread", "process"] }
 tokio-compat = { version = "0.1.6", features = ["rt-current-thread"] }
 tokio-compat-02 = "0.2.0"
 tokio-stream = "0.1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0.115", features = ["derive"] }
 sha-1 = "0.9"
 structopt = "0.3.17"
 syslog = "4"
-tokio = {version = "1.6.1", features = ["signal", "rt-multi-thread", "process"] }
+tokio = {version = "1.6.1", features = ["signal", "rt-multi-thread", "process", "io-std"] }
 tokio-compat = { version = "0.1.6", features = ["rt-current-thread"] }
 tokio-compat-02 = "0.2.0"
 tokio-stream = "0.1.7"

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -89,7 +89,7 @@ pub(crate) struct MainLoopState {
     pub(crate) autoplay: bool,
     pub(crate) volume_ctrl: VolumeCtrl,
     pub(crate) initial_volume: Option<u16>,
-    pub(crate) running_event_program: Option<Child>,
+    pub(crate) running_event_program: Option<Pin<Box<Child>>>,
     pub(crate) shell: String,
     pub(crate) device_type: DeviceType,
     pub(crate) use_mpris: bool,
@@ -117,22 +117,35 @@ impl Future for MainLoopState {
             }
 
             if let Some(mut child) = self.running_event_program.take() {
-                match child.try_wait() {
-                    // Still running...
-                    Ok(None) => self.running_event_program = Some(child),
-                    // Exited with error...
-                    Err(e) => error!("{}", e),
-                    // Exited without error...
-                    Ok(Some(_)) => (),
+                // check if child has already exited
+                if let Poll::Ready(result) = child.as_mut().poll(cx) {
+                    match result {
+                        // Exited without error...
+                        Ok(_) => (),
+                        // Exited with error...
+                        Err(e) => error!("{}", e),
+                    }
+                } else {
+                    // drop the Box that holds a reference to our child
+                    self.running_event_program = Some(child);
                 }
             }
+
             if self.running_event_program.is_none() {
                 if let Some(ref mut player_event_channel) = self.spotifyd_state.player_event_channel
                 {
                     if let Poll::Ready(Some(event)) = player_event_channel.poll_next_unpin(cx) {
                         if let Some(ref cmd) = self.spotifyd_state.player_event_program {
                             match spawn_program_on_event(&self.shell, cmd, event) {
-                                Ok(child) => self.running_event_program = Some(child),
+                                Ok(child) => {
+                                    self.running_event_program = Some({
+                                        let mut child = Box::pin(child);
+                                        // We poll the child once, so the waker is awoken once the process finishes.
+                                        // Polling on a Poll::Ready(...) is allowed in this case.
+                                        let _ = child.as_mut().poll(cx);
+                                        child
+                                    })
+                                }
                                 Err(e) => error!("{}", e),
                             }
                         }

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -119,9 +119,9 @@ impl Future for MainLoopState {
                     Box::pin(Session::connect(session_config, creds, cache));
             }
 
-            if let Some(mut child) = self.running_event_program.take() {
+            if let Some(mut future) = self.running_event_program.take() {
                 // check if child has already exited
-                if let Poll::Ready(result) = child.as_mut().poll(cx) {
+                if let Poll::Ready(result) = future.as_mut().poll(cx) {
                     match result {
                         // Exited without error...
                         Ok(_) => (),
@@ -129,8 +129,8 @@ impl Future for MainLoopState {
                         Err(e) => error!("{}", e),
                     }
                 } else {
-                    // drop the Box that holds a reference to our child
-                    self.running_event_program = Some(child);
+                    // not yet done, put it back into the `Option`
+                    self.running_event_program = Some(future);
                 }
             }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,16 +1,10 @@
 use crate::error::Error;
-use futures::Future;
 use librespot_playback::player::PlayerEvent;
 use log::info;
-use std::{
-    collections::HashMap,
-    pin::Pin,
-    process::{Output, Stdio},
-    task::{Context, Poll},
-};
+use std::{collections::HashMap, process::Stdio};
 use tokio::{
-    io::{self, AsyncWrite},
-    process::Command,
+    io::{self, AsyncWriteExt},
+    process::{self, Command},
 };
 
 /// Blocks while provided command is run in a subprocess using the provided
@@ -156,15 +150,7 @@ pub(crate) fn spawn_program_on_event(
     spawn_program(shell, cmd, env)
 }
 
-enum ChildFuture {
-    Process(Pin<Box<dyn Future<Output = io::Result<Output>>>>),
-    Stdout(io::Stdout, Vec<u8>),
-    Flush(io::Stdout),
-    Done(Result<(), Error>),
-}
-
-/// Wraps a process into a Future that executes something after the process has
-/// exited:
+/// Wraps `tokio::process::Child` so that when this `Child` exits:
 /// * successfully: It writes the contents of it's stdout to the stdout of the
 ///   main process.
 /// * unsuccesfully: It returns an error that includes the contents it's stderr
@@ -172,103 +158,45 @@ enum ChildFuture {
 ///   invoked it.
 pub(crate) struct Child {
     cmd: String,
-    future: ChildFuture,
+    child: process::Child,
     shell: String,
 }
 
 impl Child {
-    pub(crate) fn new(cmd: String, child: tokio::process::Child, shell: String) -> Self {
-        Self {
-            cmd,
-            future: ChildFuture::Process(Box::pin(child.wait_with_output())),
-            shell,
-        }
+    pub(crate) fn new(cmd: String, child: process::Child, shell: String) -> Self {
+        Self { cmd, child, shell }
     }
-}
 
-impl Future for Child {
-    type Output = Result<(), Error>;
+    pub(crate) async fn wait(self) -> Result<(), Error> {
+        let Child { cmd, shell, child } = self;
 
-    fn poll(mut self: Pin<&mut Child>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        if let ChildFuture::Process(ref mut process) = self.future {
-            if let Poll::Ready(result) = process.as_mut().poll(cx) {
-                match result {
-                    Ok(output) => {
-                        if output.status.success() {
-                            // If successful, write subprocess's stdout to main process's stdout...
-                            let stdout = io::stdout();
-                            self.future = ChildFuture::Stdout(stdout, output.stdout);
-                        } else {
-                            // If unsuccessful, return an error that includes the contents of stderr...
-                            let stderr = String::from_utf8(output.stderr);
-                            let err = match stderr {
-                                Ok(stderr) => {
-                                    Error::subprocess_with_str(&self.shell, &self.cmd, &stderr)
-                                }
-                                Err(_) => Error::subprocess(&self.shell, &self.cmd),
-                            };
-                            self.future = ChildFuture::Done(Err(err));
-                        }
-                    }
-                    Err(err) => {
-                        self.future = ChildFuture::Done(Err(Error::subprocess_with_err(
-                            &self.shell,
-                            &self.cmd,
-                            err,
-                        )));
-                    }
-                };
-            } else {
-                return Poll::Pending;
-            }
-        }
+        let output = child
+            .wait_with_output()
+            .await
+            .map_err(|e| Error::subprocess_with_err(&shell, &cmd, e))?;
 
-        if let ChildFuture::Stdout(ref mut stdout, ref output) = self.future {
-            let stdout = Pin::new(stdout);
-            if let Poll::Ready(result) = stdout.poll_write(cx, output) {
-                match result {
-                    Ok(_) => {
-                        let stdout = io::stdout();
-                        self.future = ChildFuture::Flush(stdout);
-                    }
-                    Err(e) => {
-                        self.future = ChildFuture::Done(Err(Error::subprocess_with_err(
-                            &self.shell,
-                            &self.cmd,
-                            e,
-                        )));
-                    }
-                }
-            } else {
-                return Poll::Pending;
-            }
-        }
+        if output.status.success() {
+            // If successful, write subprocess's stdout to main process's stdout...
+            let mut stdout = io::stdout();
 
-        if let ChildFuture::Flush(ref mut stdout) = self.future {
-            let stdout = Pin::new(stdout);
-            if let Poll::Ready(result) = stdout.poll_flush(cx) {
-                match result {
-                    Ok(_) => self.future = ChildFuture::Done(Ok(())),
-                    Err(e) => {
-                        self.future = ChildFuture::Done(Err(Error::subprocess_with_err(
-                            &self.shell,
-                            &self.cmd,
-                            e,
-                        )))
-                    }
-                }
-            } else {
-                return Poll::Pending;
-            }
-        }
+            stdout
+                .write_all(&output.stdout)
+                .await
+                .map_err(|e| Error::subprocess_with_err(&shell, &cmd, e))?;
 
-        let new_error = Error::subprocess(&self.shell, &self.cmd);
-        if let ChildFuture::Done(ref mut result) = self.future {
-            // we can't clone the result (errors don't need to be clonable), so we just replace it with a simpler version
-            let result = std::mem::replace(result, Err(new_error));
-            Poll::Ready(result)
+            stdout
+                .flush()
+                .await
+                .map_err(|e| Error::subprocess_with_err(&shell, &cmd, e))?;
+
+            Ok(())
         } else {
-            unreachable!("every other case is handled above")
+            // If unsuccessful, return an error that includes the contents of stderr...
+            let err = match String::from_utf8(output.stderr) {
+                Ok(stderr) => Error::subprocess_with_str(&shell, &cmd, &stderr),
+                Err(_) => Error::subprocess(&shell, &cmd),
+            };
+            Err(err)
         }
     }
 }


### PR DESCRIPTION
As outlined in https://github.com/Spotifyd/spotifyd/issues/959#issuecomment-1016631025, handling too many events in a row can lead to the channel not being polled enough and the events then stacking up in the channel.

This fixes the behavior by implementing the hook process management asynchronously. ~~After the process has finished, the output is written with blocking `io::stdout()` to stdout (as before). I'll probably reimplement this in a non-blocking manner, thus still a "draft".~~

I would be happy, if someone else could already test the PR, for me it's working fine!

related: #959, #913