### PR TITLE
improve RaspberryPi installation instructions

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,7 +7,6 @@
   - [Installing on Ubuntu (from source)](./installation/Ubuntu.md)
   - [Cross Compiling on Ubuntu](./installation/Cross-Compiling-on-Ubuntu.md)
   - [Installing with Homebrew on macOS](./installation/MacOS.md)
-  - [Feature Flags](./Feature-flags.md)
 - [Configuration](./config/README.md)
   - [CLI options](./config/Cli.md)
   - [Configuration file](./config/File.md)

--- a/docs/src/installation/Raspberry-Pi.md
+++ b/docs/src/installation/Raspberry-Pi.md
@@ -40,16 +40,18 @@ Input the following data. Change the **username**, **password**, **device_name**
 username = "USER"
 password = "PASS"
 backend = "alsa"
-device = alsa_audio_device # Given by `aplay -L`
+device = "default" # possible values are listed by `aplay -L`
 mixer = "PCM"
 volume-controller = "alsa" # or alsa_linear, or softvol
-#onevent = command_run_on_playback_event
+#onevent = "command_run_on_playback_event"
 device_name = "name_in_spotify_connect"
-bitrate = 96|160|320
+bitrate = 160 # possible values: 96, 160, 320
 cache_path = "cache_directory"
 volume-normalisation = true
 normalisation-pregain = -10
 ```
+
+For a full list of options, see [here](../config/File.md).
 
 ## Start the service
 


### PR DESCRIPTION
This fixes a common source of confusion (#1031, #1051) and removes an unused page in the summary.

Thanks @Jedikops for the initial proposed solution.

fixes #1031, possibly #1051