### PR TITLE
Minor comment cleanup in example config file

### DIFF
--- a/docs/src/config/File.md
+++ b/docs/src/config/File.md
@@ -29,18 +29,16 @@ password_cmd = "command_that_writes_password_to_stdout"
 # can't be used simultaneously.
 use_keyring = true
 
-#
 # If set to true, `spotifyd` tries to bind to the session dbus
 # and expose MPRIS controls. When running headless, without a dbus session,
 # then set this to false to avoid binding errors
-#
 use_mpris = true
 
-# The audio backend used to play the your music. To get
+# The audio backend used to play music. To get
 # a list of possible backends, run `spotifyd --help`.
 backend = "alsa" # use portaudio for macOS [homebrew]
 
-# The alsa audio device to stream audio to. To get a
+# The alsa audio device to stream audio. To get a
 # list of valid devices, run `aplay -L`,
 device = "alsa_audio_device"  # omit for macOS
 


### PR DESCRIPTION
As I was reading the documentation I found some grammatical errors and took the liberty to fix them. 

Proposing a few minor corrections of comments in the example configuration file.