### PR TITLE
MPRIS Device Name

### DIFF
--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -166,7 +166,10 @@ async fn create_dbus_server(
 
     // TODO: The first `true` allows us to replace orphaned dbus servers from previous sessions
     // later. We should instead properly release the name when the session ends.
-    let path = format!("org.mpris.MediaPlayer2.spotifyd.instance{b}", b = std::process::id());
+    let path = format!(
+        "org.mpris.MediaPlayer2.spotifyd.instance{b}",
+        b = std::process::id()
+    );
     conn.request_name(path, true, true, true)
         .await
         .expect("Failed to register dbus player name");

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -168,6 +168,7 @@ async fn create_dbus_server(
         "org.mpris.MediaPlayer2.spotifyd.instance{}",
         std::process::id()
     );
+    
     // TODO: The first `true` allows us to replace orphaned dbus servers from previous sessions
     // later. We should instead properly release the name when the session ends.
     conn.request_name(path, true, true, true)

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -164,12 +164,12 @@ async fn create_dbus_server(
         panic!("Lost connection to D-Bus: {}", err);
     });
 
-    // TODO: The first `true` allows us to replace orphaned dbus servers from previous sessions
-    // later. We should instead properly release the name when the session ends.
     let path = format!(
         "org.mpris.MediaPlayer2.spotifyd.instance{}",
         std::process::id()
     );
+    // TODO: The first `true` allows us to replace orphaned dbus servers from previous sessions
+    // later. We should instead properly release the name when the session ends.
     conn.request_name(path, true, true, true)
         .await
         .expect("Failed to register dbus player name");

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -168,7 +168,7 @@ async fn create_dbus_server(
         "org.mpris.MediaPlayer2.spotifyd.instance{}",
         std::process::id()
     );
-    
+
     // TODO: The first `true` allows us to replace orphaned dbus servers from previous sessions
     // later. We should instead properly release the name when the session ends.
     conn.request_name(path, true, true, true)

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -167,8 +167,8 @@ async fn create_dbus_server(
     // TODO: The first `true` allows us to replace orphaned dbus servers from previous sessions
     // later. We should instead properly release the name when the session ends.
     let path = format!(
-        "org.mpris.MediaPlayer2.spotifyd.instance{b}",
-        b = std::process::id()
+        "org.mpris.MediaPlayer2.spotifyd.instance{}",
+        std::process::id()
     );
     conn.request_name(path, true, true, true)
         .await

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -166,7 +166,8 @@ async fn create_dbus_server(
 
     // TODO: The first `true` allows us to replace orphaned dbus servers from previous sessions
     // later. We should instead properly release the name when the session ends.
-    conn.request_name("org.mpris.MediaPlayer2.spotifyd", true, true, true)
+    let path = format!("org.mpris.MediaPlayer2.spotifyd.instance{b}", b = std::process::id());
+    conn.request_name(path, true, true, true)
         .await
         .expect("Failed to register dbus player name");
 


### PR DESCRIPTION
Added a compilation option to append device names to the end of dbus paths, this allows multiple Spotifyd daemons to be running each with a unique dbus object for MPRIS as long as they have unique device names.