### PR TITLE
only use cache if username matches

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -147,11 +147,16 @@ fn get_credentials(
     username: &Option<String>,
     password: &Option<String>,
 ) -> Option<Credentials> {
-    if let (Some(username), Some(password)) = (username, password) {
-        return Some(Credentials::with_password(username, password));
+    if let Some(credentials) = cache.as_ref().and_then(Cache::credentials) {
+        if username.as_ref() == Some(&credentials.username) {
+            return Some(credentials);
+        }
     }
 
-    cache.as_ref()?.credentials()
+    Some(Credentials::with_password(
+        username.as_ref()?,
+        password.as_ref()?,
+    ))
 }
 
 fn find_backend(name: Option<&str>) -> fn(Option<String>, AudioFormat) -> Box<dyn Sink> {


### PR DESCRIPTION
This is a follow-up to #1019 and reorders the credential cache logic.

Previously:

- `username` and `password` are specified: use that
- cached credentials exist: use that
- else: start discovery

Now:

- cached credentials exist for given `username`: use that
- `username` and `password` are specified: use that
- else: start discovery

Also, a cache initialization failure is properly reported to the user.