### PR TITLE
always emit the album art URL representing the largest image to DBus

### DIFF
--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -776,7 +776,7 @@ fn insert_metadata(m: &mut HashMap<String, Variant<Box<dyn RefArg>>>, item: Play
         Variant(Box::new(
             item.images
                 .into_iter()
-                .next()
+                .max_by_key(|i| i.width.ok_or(0))
                 .map(|i| i.url)
                 .unwrap_or_default(),
         )),

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -776,7 +776,7 @@ fn insert_metadata(m: &mut HashMap<String, Variant<Box<dyn RefArg>>>, item: Play
         Variant(Box::new(
             item.images
                 .into_iter()
-                .max_by_key(|i| i.width.ok_or(0))
+                .max_by_key(|i| i.width.unwrap_or(0))
                 .map(|i| i.url)
                 .unwrap_or_default(),
         )),


### PR DESCRIPTION
This patch ensures we always return the clearest possible album art URL as part of the MPRIS event sent over DBus. I noticed this after [mpris-notifier](https://github.com/l1na-forever/mpris-notifier) started showing blurry album art. Upon further inspection, the first album art item in the list returned by Spotify had become the smallest image's URL, rather than the largest.

Before:
![screenshot_20221028_005919254815550](https://user-images.githubusercontent.com/61861965/198535856-34ba6930-4eb5-4c76-b16f-6d204fc7c45a.png)

After:
![screenshot_20221028_005855845708237](https://user-images.githubusercontent.com/61861965/198535886-29a30d63-8d5a-4657-a56d-ce35e6b876f1.png)

