### PR TITLE
Update repository for 0.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 - Implement the `PropertiesChanged` and `Seeked` events for the MPRIS-interface ([#1025])
 - Add `cache_size` configuration option ([#1092])
+- Add `dbus_type` configuration option ([#954])
 - Added formal documentation of the minimum required Rust version - which is currently 1.62 ([#1127])
 ### Changed
-- Improvements to the documentation ([#955], [#1030], [#1039], [#1054], [#1055], [#1067])
+- Improvements to the documentation ([#894], [#955], [#1030], [#1039], [#1054], [#1055], [#1067])
 - Fix cumulating delay in `on_song_change_hook` ([#1059])
 - Only enable one of zeroconf discovery and password-authentication at the same time ([#1059])
 - Convert mainloop to using `async` / `await` ([#1059])
@@ -19,9 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `spotifyd` bus name unique ([#1100])  
   **Note:** If you were relying on the consistent bus name of `org.mpris.MediaPlayer2.spotifyd`,
   you can adapt your script e.g. by querying the name like `qdbus | grep "org.mpris.MediaPlayer2.spotifyd"`
+- Fix wrong handling of credential cache ([#1121])
 ### Removed
 - Replace redundant `reqwest` dependency ([#1120])
 
+[#894]: https://github.com/Spotifyd/spotifyd/pull/894
+[#954]: https://github.com/Spotifyd/spotifyd/pull/954
 [#955]: https://github.com/Spotifyd/spotifyd/pull/955
 [#1025]: https://github.com/Spotifyd/spotifyd/pull/1025
 [#1030]: https://github.com/Spotifyd/spotifyd/pull/1030
@@ -35,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1100]: https://github.com/Spotifyd/spotifyd/pull/1100
 [#1108]: https://github.com/Spotifyd/spotifyd/pull/1108
 [#1120]: https://github.com/Spotifyd/spotifyd/pull/1120
+[#1121]: https://github.com/Spotifyd/spotifyd/pull/1120
 
 ## [0.3.3]
 ### Added 
@@ -77,7 +82,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.24]
 
-[Unreleased]: https://github.com/Spotifyd/spotifyd/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/Spotifyd/spotifyd/compare/v0.3.4...HEAD
+[0.3.4]: https://github.com/Spotifyd/spotifyd/releases/tag/v0.3.4
 [0.3.3]: https://github.com/Spotifyd/spotifyd/releases/tag/v0.3.3
 [0.3.1]: https://github.com/Spotifyd/spotifyd/releases/tag/v0.3.1
 [0.3.0]: https://github.com/Spotifyd/spotifyd/releases/tag/v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.4]
 ### Added 
 - Implement the `PropertiesChanged` and `Seeked` events for the MPRIS-interface ([#1025])
 - Add `cache_size` configuration option ([#1092])
+- Added formal documentation of the minimum required Rust version - which is currently 1.62 ([#1127])
 ### Changed
 - Improvements to the documentation ([#955], [#1030], [#1039], [#1054], [#1055], [#1067])
 - Fix cumulating delay in `on_song_change_hook` ([#1059])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2760,7 +2760,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spotifyd"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "alsa 0.5.0",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "spotifyd"
 description = "A Spotify daemon"
 repository = "https://github.com/Spotifyd/spotifyd"
 license = "GPL-3.0-only"
-version = "0.3.3"
+version = "0.3.4"
 rust-version = "1.62"
 
 [dependencies]

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -776,7 +776,7 @@ fn insert_metadata(m: &mut HashMap<String, Variant<Box<dyn RefArg>>>, item: Play
         Variant(Box::new(
             item.images
                 .into_iter()
-                .next()
+                .max_by_key(|i| i.width.unwrap_or(0))
                 .map(|i| i.url)
                 .unwrap_or_default(),
         )),


### PR DESCRIPTION
Closes #1110

This adds a line about the minimum rust version change which landed earlier today,  replaces the title of the "Unreleased" section with 0.3.4, and bumps the version number in Cargo.toml and Cargo.lock