### PR TITLE
New DBUS method: TransferPlayback

### DIFF
--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -575,14 +575,14 @@ async fn create_dbus_server(
                 match sp_client.transfer_playback(&device_id, Some(true)) {
                     Ok(_) =>Ok(()),
                     Err(err) => {
-                        let e = format!("RSpotify error: {}", err);
+                        let e = format!("TransferPlayback failed: {}", err);
                         error!("{}", e);
                         Err(MethodErr::failed(&e))
                     },
                 }
             } else {
                 let msg = format!("Could not find device with name {}", mv_device_name);
-                warn!("{}", msg);
+                warn!("TransferPlayback: {}", msg);
                 Err(MethodErr::failed(&msg))
             }
         });
@@ -736,11 +736,11 @@ fn get_device_id(sp_client: &Arc<AuthCodeSpotify>, device_name: &String, only_ac
         Ok(devices) => devices.into_iter().find_map(|d| {
             if d.name.eq(device_name) && (d.is_active || !only_active)  {
                 info!("Found device: {}, active: {}", d.name, d.is_active);
-                Some(d.id)
+                d.id
             } else {
                 None
             }
-        }).flatten(),
+        }),
         Err(err) => {
             error!("Get devices error: {}", err);
             None

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -742,12 +742,6 @@ fn get_device_id(sp_client: &Arc<AuthCodeSpotify>, device_name: &String, only_ac
             }
         }).flatten(),
         Err(err) => {
-            let expires_at = sp_client.get_token()
-                .lock()
-                .ok()
-                .unwrap().as_ref().unwrap().expires_at.unwrap();
-            info!("Token expires at: {}", expires_at);
-
             error!("Get devices error: {}", err);
             None
         }

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -457,9 +457,7 @@ async fn create_dbus_server(
                 Ok("Stopped".to_string())
             });
 
-        let mv_device_name = device_name.clone();
         let sp_client = Arc::clone(&spotify_api_client);
-        let sp_client2 = Arc::clone(&spotify_api_client);
         b.property("Shuffle")
             .emits_changed_false()
             .get(move |_, _| {
@@ -469,23 +467,6 @@ async fn create_dbus_server(
                     .flatten()
                     .map_or(false, |p| p.shuffle_state);
                 Ok(shuffle_status)
-            })
-            .set(move |_, _, value| {
-                let device_id = get_device_id(&sp_client2, &mv_device_name, true);
-                if let Some(device_id) = device_id {
-                    match sp_client2.shuffle(value, Some(&device_id)) {
-                        Ok(_) => Ok(None),
-                        Err(err) => {
-                            let e = format!("SetShuffle failed: {}", err);
-                            error!("{}", e);
-                            Err(MethodErr::failed(&e))
-                        }
-                    }
-                } else {
-                    let msg = format!("Could not find device with name {}", mv_device_name);
-                    warn!("SetShuffle: {}", msg);
-                    Err(MethodErr::failed(&msg))
-                }
             });
 
         b.property("Rate").emits_changed_const().get(|_, _| Ok(1.0));
@@ -768,17 +749,6 @@ fn get_device_id(
             }
         }),
         Err(err) => {
-            let expires_at = sp_client
-                .get_token()
-                .lock()
-                .ok()
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .expires_at
-                .unwrap();
-            info!("Token expires at: {}", expires_at);
-
             error!("Get devices error: {}", err);
             None
         }

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -234,12 +234,12 @@ async fn create_dbus_server(
         b.method("VolumeUp", (), (), move |_, _, (): ()| {
             local_spirc.volume_up();
             Ok(())
-        });
+        }).deprecated();
         let local_spirc = spirc.clone();
         b.method("VolumeDown", (), (), move |_, _, (): ()| {
             local_spirc.volume_down();
             Ok(())
-        });
+        }).deprecated();
         let local_spirc = spirc.clone();
         b.method("Next", (), (), move |_, _, (): ()| {
             local_spirc.next();

--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -734,14 +734,14 @@ async fn create_dbus_server(
 }
 
 fn get_device_id(
-    sp_client: &Arc<AuthCodeSpotify>,
+    sp_client: &AuthCodeSpotify,
     device_name: &str,
     only_active: bool,
 ) -> Option<String> {
     let device_result = sp_client.device();
     match device_result {
         Ok(devices) => devices.into_iter().find_map(|d| {
-            if d.name.eq(device_name) && (d.is_active || !only_active) {
+            if d.name == device_name && (d.is_active || !only_active) {
                 info!("Found device: {}, active: {}", d.name, d.is_active);
                 d.id
             } else {


### PR DESCRIPTION
This is a new TransferPlayback method available for DBUS. It's useful in my setup where spotifyd is part of audio system based on dietpi micro computer. It's used to transfer playback from other active spotify device.

Also i discovered weird error when setting my spotifyd device type to S_T_B. It was returned from device() method of spotify client as STB (all capitals) and was throwing error:
 ```
 json parse error: unknown variant `STB`, expected one of `Computer`, `Tablet`, `Smartphone`, `Speaker`, `Tv`, `Avr`, `Stb`, `AudioDongle`, `GameConsole`, `CastVideo`, `CastAudio`, `Automobile`, `Unknown` at line 16 column 18
```
 I didn't find `STB` anywhere in code so i assume that spotify changes that somehow ?