### PR TITLE
Add project website link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 > An open source Spotify client running as a UNIX daemon.
 
+https://spotifyd.rs
+
 Spotifyd streams music just like the official client, but is more lightweight and supports more platforms. Spotifyd also supports the Spotify Connect protocol, which makes it show up as a device that can be controlled from the official clients.
 
 > __Note:__ Spotifyd requires a Spotify Premium account.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 > An open source Spotify client running as a UNIX daemon.
 
-https://spotifyd.rs
+[Project Website](https://spotifyd.rs)
 
 Spotifyd streams music just like the official client, but is more lightweight and supports more platforms. Spotifyd also supports the Spotify Connect protocol, which makes it show up as a device that can be controlled from the official clients.
 


### PR DESCRIPTION
I'd have preferred to add the mdbook link and then put the project website link in the sidebar, but in the meantime I think this'll do.

Also, as an aside, right now https://spotifyd.rs just links to the github, docs, matrix, etc. If anyone has suggestions for changes or things to add, just let me know (the code is hosted at https://github.com/slondr/spotifyd.rs).