### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This enables the Dependabot feature which submits PRs for dep upgrades even when they aren't security-related.

I have no idea if this would be useful or not but I figure hey why not try it out 