### PR TITLE
add CNAME to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,3 +29,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/book
+          cname: docs.spotifyd.rs


### PR DESCRIPTION
This prevents the action to overwrite our custom domain name. See [here](https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-add-cname-file-cname) for documentation.