### PR TITLE
re-enable credential caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Credential caching has been re-enabled. ([#1214])
+
+[#1214]: https://github.com/Spotifyd/spotifyd/pull/1214
+
 ## [0.3.5]
 
 We now have a [project website](https://spotifyd.rs) (thanks @slondr!) and a [matrix room](https://matrix.to/#/#spotifyd:matrix.org).

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -96,7 +96,7 @@ impl MainLoop {
         let session_config = self.session_config.clone();
         let cache = self.spotifyd_state.cache.clone();
 
-        Session::connect(session_config, creds, cache, false)
+        Session::connect(session_config, creds, cache, true)
             .await
             .map(|(session, _creds)| session)
     }


### PR DESCRIPTION
I just noticed that we disabled credential caching by accident during the `librespot` upgrade.