### PR TITLE
retry enabling discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- retry enabling discovery several times before exiting ([#1228])
+
 ### Changed
 - Credential caching has been re-enabled. ([#1214])
 
 [#1214]: https://github.com/Spotifyd/spotifyd/pull/1214
+[#1228]: https://github.com/Spotifyd/spotifyd/pull/1228
 
 ## [0.3.5]
 


### PR DESCRIPTION
fixes #1227

This retries to enable discovery, if it fails, for several times before giving up to prevent race conditions e.g. on startup.
Before merging this, we should probably wait for feedback on the linked issue as this might be a `libmdns` issue that could be fixed instead.