### PR TITLE
fix alsa mixer calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Credential caching has been re-enabled. ([#1214])
 
+### Fixed
+- alsa mixer: volume calculation has been fixed ([#1229])
+
 [#1214]: https://github.com/Spotifyd/spotifyd/pull/1214
+[#1229]: https://github.com/Spotifyd/spotifyd/pull/1229
 
 ## [0.3.5]
 

--- a/src/alsa_mixer.rs
+++ b/src/alsa_mixer.rs
@@ -25,9 +25,9 @@ impl AlsaMixer {
 
         let volume_steps = (max - min) as f64;
         let normalised_volume = if self.linear_scaling {
-            ((f64::from(volume) / f64::from(u16::max_value())) * volume_steps) as i64 + min
+            (((volume as f64) / (u16::max_value() as f64)) * volume_steps) as i64 + min
         } else {
-            (f64::from(volume).log(f64::from(u16::max_value())) * volume_steps).floor() as i64 + min
+            ((volume as f64 + 1.0).log((u16::MAX as f64) + 1.0) * volume_steps).floor() as i64 + min
         };
 
         elem.set_playback_volume_all(normalised_volume)?;
@@ -55,8 +55,8 @@ impl Mixer for AlsaMixer {
                 elem.get_playback_volume(alsa::mixer::SelemChannelId::mono())
                     .ok()
                     .map(|volume| {
-                        let volume_steps = max - min + 1;
-                        ((volume - min) * (0xFFFF / volume_steps)) as u16
+                        (((volume - min) as f64 / (max - min) as f64) * (u16::MAX as f64)).floor()
+                            as u16
                     })
             }) {
             Some(vol) => vol,


### PR DESCRIPTION
fixes #1222

I hope, this fixes the issues mentioned with `alsa` and `alsa_linear`. Please note that one of them will behave weirdly on your system depending on, whether your alsa control is linear or not. (At least that is what I assume based on my experience...) However, they should both be able to reach 0% and not be reset when hitting play.

Any testing is appreciated. (maybe @Arbee4ever?)