### PR TITLE
Update Arch Linux package URL in README.md

### DIFF
--- a/docs/src/installation/README.md
+++ b/docs/src/installation/README.md
@@ -10,7 +10,7 @@ The provided binaries come in two flavours, `slim` and `full`. Each are compiled
 
 There are packages for the following systems:
 
-- [Arch Linux (via the Community repository)](https://archlinux.org/packages/community/x86_64/spotifyd/)
+- [Arch Linux (via the Extra repository)](https://archlinux.org/packages/extra/x86_64/spotifyd/)
 - [MacOS (via homebrew)](./MacOS.md)
 
 ## Building from source


### PR DESCRIPTION
The old URL returns 404 now.