### PR TITLE
Explain that credentials from keyring can't be accessed in system service

### DIFF
--- a/docs/src/config/File.md
+++ b/docs/src/config/File.md
@@ -146,6 +146,8 @@ device_type = "speaker"
 
 - **`use_keyring`** config entry / **`--use-keyring`** CLI flag <!-- omit in toc -->
 
+  > __Note:__ If choosing the user's keyring to store login credentials, running spotifyd as a systemd _system service_ is no longer possible. A system wide service cannot access a specific user's keyring. In this case, make sure to run spotifyd as a systemd _user service_. See [systemd configuration][services/Systemd.md].
+
   This features leverages [Linux's DBus Secret Service API][secret-storage-specification] or native macOS keychain in order to forgo the need to store your password directly in the config file. To use it, compile with the `dbus_keyring` feature and set the `use-keyring` config entry to `true` or pass the `--use-keyring` CLI flag  during start to the daemon. Remove the `password` and/or `password_cmd` config entries.
 
   Your keyring entry needs to have the following attributes set:

--- a/docs/src/config/services/Systemd.md
+++ b/docs/src/config/services/Systemd.md
@@ -20,7 +20,7 @@ systemctl --user enable spotifyd.service --now
 ## As a system wide service
 
 > [!IMPORTANT]  
-> When running spotifyd as a system wide service, it is not possible to access a user's keyring to obtain login credentials. Do not set `use_keyring = true` and do not specify `--use-keyring`, when running as a system wide service.
+> When running spotifyd as a system wide service, it is not possible to access a user's keyring to obtain login credentials. Do not set `use_keyring = true` and do not specify `--use-keyring`, when running as a system wide service. To be able to access login credentials stored in the user's keyring, run spotifyd as a user service, as decribed above.
 
 A `systemd.service` unit file is provided to help run spotifyd as a service on systemd-based systems. The file `contrib/spotifyd.service` should be copied to:
 

--- a/docs/src/config/services/Systemd.md
+++ b/docs/src/config/services/Systemd.md
@@ -19,6 +19,9 @@ systemctl --user enable spotifyd.service --now
 
 ## As a system wide service
 
+> [!IMPORTANT]  
+> When running spotifyd as a system wide service, it is not possible to access a user's keyring to obtain login credentials. Do not set `use_keyring = true` and do not specify `--use-keyring`, when running as a system wide service.
+
 A `systemd.service` unit file is provided to help run spotifyd as a service on systemd-based systems. The file `contrib/spotifyd.service` should be copied to:
 
 ```bash


### PR DESCRIPTION
This took me a while to figure out, so I created a PR updating the docs with something that's missing, IMO.

Systemd allows running spotifyd as a system service, or as a user service.

When running as a system service, accessing login credentials stored in a user's keyring is not possible.

When using the user's keyring to store login credentials, as described in the docs, make sure to also run the spotifyd as a user service.