### PR TITLE
Recognise OpenBSD to unbreak build

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,6 +8,7 @@
   - [Cross Compiling on Ubuntu](./installation/Cross-Compiling-on-Ubuntu.md)
   - [Installing with Homebrew on macOS](./installation/MacOS.md)
   - [Installing on FreeBSD](./installation/FreeBSD.md)
+  - [Installing on OpenBSD](./installation/OpenBSD.md)
 - [Configuration](./config/README.md)
   - [CLI options](./config/Cli.md)
   - [Configuration file](./config/File.md)

--- a/docs/src/config/File.md
+++ b/docs/src/config/File.md
@@ -44,7 +44,7 @@ dbus_type = "session"
 
 # The audio backend used to play music. To get
 # a list of possible backends, run `spotifyd --help`.
-backend = "alsa" # use portaudio for macOS [homebrew]
+backend = "alsa" # use portaudio for BSD and macOS [homebrew]
 
 # The alsa audio device to stream audio. To get a
 # list of valid devices, run `aplay -L`,
@@ -66,7 +66,7 @@ mixer = "PCM"  # omit for macOS
 # The volume controller. Each one behaves different to
 # volume increases. For possible values, run
 # `spotifyd --help`.
-volume_controller = "alsa"  # use softvol for macOS
+volume_controller = "alsa"  # use softvol for BSD and macOS
 
 # A command that gets executed in your shell after each song changes.
 on_song_change_hook = "command_to_run_on_playback_events"

--- a/docs/src/installation/OpenBSD.md
+++ b/docs/src/installation/OpenBSD.md
@@ -1,0 +1,25 @@
+# OpenBSD install guide
+
+`spotifyd` is available on all supported Rust architectures:
+
+* aarch64
+* amd64
+* i386
+* powerpc64
+* riscv64
+* sparc64
+
+## Install
+
+```sh
+# pkg_add spotifyd
+```
+
+## Configuring spotifyd
+
+The official package uses PortAudio and works out of the box, no configuration is required.
+
+## Running spotifyd
+
+You may start `spotifyd` as background daemon in your `~/.xsession` X11 startup script
+or have clients like `spotify-qt` start/stop it accordingly.

--- a/docs/src/installation/README.md
+++ b/docs/src/installation/README.md
@@ -83,6 +83,6 @@ To enable an additional audio backend, pass `<audio_backend_name>_backend` as a 
 | Feature Flag | Description                                                                         |
 |--------------|-------------------------------------------------------------------------------------|
 | dbus_keyring | Provides password authentication over the system's keyring (supports all platforms) |
-| dbus_mpris   | Provides multimedia key support (Linux only)                                      |
+| dbus_mpris   | Provides multimedia key support (Linux and BSD only)                                |
 
 > __Note:__ Compiling Spotifyd with all features and the pulseaudio backend on Ubuntu would result in the following command: `cargo build --release --no-default-features --features pulseaudio_backend,dbus_keyring,dbus_mpris`

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use log::trace;
 use std::env;
 
-#[cfg(any(target_os = "freebsd", target_os = "linux"))]
+#[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "openbsd"))]
 fn get_shell_ffi() -> Option<String> {
     use libc::{geteuid, getpwuid_r};
     use std::{ffi::CStr, mem, ptr};


### PR DESCRIPTION
```
  error[E0425]: cannot find value `get_shell_ffi` in this scope
    --> src/utils.rs:69:48
```

Otherwise spotifyd-0.3.5 works great on OpenBSD/amd64 7.4-current.