### PR TITLE
Bump keyring to latest release 2.3.0 to add OpenBSD support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "2.0.5"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9549a129bd08149e0a71b2d1ce2729780d47127991bfd0a78cc1df697ec72492"
+checksum = "b52a1d320b55eacc02d4561fed9714af4e98b7989cf4e696bee192b03fc99720"
 dependencies = [
  "byteorder",
  "lazy_static",


### PR DESCRIPTION
After 2.2.0 I submitted https://github.com/hwchen/keyring-rs/pull/156 which turned into 2.3.0 today.

OpenBSD's port currently needs patches, see PR for details.

I have only tested spotifyd's 0.3.5 release with this keyring bumped 2.3.0 instead of patching 2.0.5 and it works.

Done with `cargo update keyring`.