### PR TITLE
Add support for `rodiojack` backend.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -619,6 +619,7 @@ dependencies = [
  "alsa 0.6.0",
  "core-foundation-sys",
  "coreaudio-rs",
+ "jack",
  "jni",
  "js-sys",
  "lazy_static",
@@ -1421,6 +1422,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "jack"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2ac12f11bb369f3c50d24dbb9fdb00dc987434c9dd622a12c13f618106e153"
+dependencies = [
+ "bitflags 1.3.2",
+ "jack-sys",
+ "lazy_static",
+ "libc",
+ "log",
+]
+
+[[package]]
+name = "jack-sys"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b91f2d2d10bc2bab38f4dfa4bc77123a988828af39dd3f30dd9db14d44f2cc1"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "libloading 0.6.7",
+ "pkg-config",
+]
+
+[[package]]
 name = "jni"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1534,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
 dependencies = [
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
+dependencies = [
+ "cfg-if",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ default = ["alsa_backend"]
 portaudio_backend = ["librespot-playback/portaudio-backend"]
 pulseaudio_backend = ["librespot-playback/pulseaudio-backend"]
 rodio_backend = ["librespot-playback/rodio-backend"]
+rodiojack_backend = ["librespot-playback/rodiojack-backend"]
 
 [package.metadata.deb]
 depends = "$auto, systemd, pulseaudio"

--- a/docs/src/installation/Feature-flags.md
+++ b/docs/src/installation/Feature-flags.md
@@ -60,3 +60,15 @@ cargo build --release --no-default-features --features="rodio_backend"
 On Linux you will need the development package for alsa and make/gcc. (`libasound2-dev`,`build-essential` on debian, `alsa-lib-devel`,`make`,`gcc` on fedora)
 
 [mpris-specification]: https://specifications.freedesktop.org/mpris-spec/latest/
+
+### JACK Audio Connection Kit
+
+To use the [JACK](http://jackaudio.org) backend on Linux, compile with the `--features` flag to enable it:
+
+```bash
+cargo build --release --no-default-features --features="rodiojack_backend"
+```
+
+You will need the development packages for alsa, make/gcc, and JACK. (`libasound2-dev`, `build-essential`, and `libjack-dev` on Debian; `alsa-lib-devel`, `make`, `gcc`, and `jack-audio-connection-kit-devel` on Fedora.)
+
+> __Note__: when Spotifyd starts with this backend, it will create a JACK output device named `cpal_client_out` with two ports: `out_0` for the left channel and `out_1` for the right.

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,7 +25,9 @@ const CONFIG_FILE_NAME: &str = "spotifyd.conf";
     feature = "pulseaudio_backend",
     feature = "portaudio_backend",
     feature = "alsa_backend",
-    feature = "rodio_backend"
+    feature = "rodio_backend",
+    feature = "rodiojack_backend",
+    feature = "jackaudio_backend",
 )))]
 compile_error!("At least one of the backend features is required!");
 static BACKEND_VALUES: &[&str] = &[
@@ -37,6 +39,10 @@ static BACKEND_VALUES: &[&str] = &[
     "portaudio",
     #[cfg(feature = "rodio_backend")]
     "rodio",
+    #[cfg(feature = "rodiojack_backend")]
+    "rodiojack",
+    #[cfg(feature = "jackaudio_backend")]
+    "jackaudio",
 ];
 
 /// The backend used by librespot
@@ -47,6 +53,7 @@ pub enum Backend {
     PortAudio,
     PulseAudio,
     Rodio,
+    RodioJack,
 }
 
 fn default_backend() -> Backend {
@@ -62,6 +69,7 @@ impl FromStr for Backend {
             "portaudio" => Ok(Backend::PortAudio),
             "pulseaudio" => Ok(Backend::PulseAudio),
             "rodio" => Ok(Backend::Rodio),
+            "rodiojack" => Ok(Backend::RodioJack),
             _ => unreachable!(),
         }
     }
@@ -74,6 +82,7 @@ impl fmt::Display for Backend {
             Backend::PortAudio => write!(f, "portaudio"),
             Backend::PulseAudio => write!(f, "pulseaudio"),
             Backend::Rodio => write!(f, "rodio"),
+            Backend::RodioJack => write!(f, "rodiojack"),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,6 @@ const CONFIG_FILE_NAME: &str = "spotifyd.conf";
     feature = "alsa_backend",
     feature = "rodio_backend",
     feature = "rodiojack_backend",
-    feature = "jackaudio_backend",
 )))]
 compile_error!("At least one of the backend features is required!");
 static BACKEND_VALUES: &[&str] = &[
@@ -41,8 +40,6 @@ static BACKEND_VALUES: &[&str] = &[
     "rodio",
     #[cfg(feature = "rodiojack_backend")]
     "rodiojack",
-    #[cfg(feature = "jackaudio_backend")]
-    "jackaudio",
 ];
 
 /// The backend used by librespot


### PR DESCRIPTION
The underlying `librespot` library already supports the JACK audio backend via `rodio`. Enabling it in `spotifyd` turns out to be dead simple--just needed to add the config enum elements to pass it through!

NOTE: I have tested this on my machine running Debian testing ("trixie"). The documentation for Fedora is based on the upstream docs for librespot: https://github.com/librespot-org/librespot/blob/329a1b16074af4d1a8abe2ed017b5d4a4a070ea1/COMPILING.md#audio-library-dependencies