### PR TITLE
Enable build on android

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,12 @@
 use log::trace;
 use std::env;
 
-#[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "openbsd", target_os = "android"))]
+#[cfg(any(
+    target_os = "freebsd",
+    target_os = "linux",
+    target_os = "openbsd",
+    target_os = "android"
+))]
 fn get_shell_ffi() -> Option<String> {
     use libc::{geteuid, getpwuid_r};
     use std::{ffi::CStr, mem, ptr};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use log::trace;
 use std::env;
 
-#[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "openbsd"))]
+#[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "openbsd", target_os = "android"))]
 fn get_shell_ffi() -> Option<String> {
     use libc::{geteuid, getpwuid_r};
     use std::{ffi::CStr, mem, ptr};


### PR DESCRIPTION
This enables build in Termux on android

As a "proof" I'm providing a screenshot from the phone that it actually builds (with some features restricted) and it runs.

Bulit with:
```
cargo build --release --no-default-features --features pulseaudio_backend
```

and run with 
```
DISPLAY=0 ./target/release/spotifyd --no-daemon
```

![Screenshot_20241216-134824](https://github.com/user-attachments/assets/25a9106b-080e-472a-a148-e40375158331)
