### PR TITLE
Add new device types

### DIFF
--- a/docs/src/config/File.md
+++ b/docs/src/config/File.md
@@ -50,8 +50,8 @@ backend = "alsa" # use portaudio for BSD and macOS [homebrew]
 # list of valid devices, run `aplay -L`,
 device = "alsa_audio_device"  # omit for macOS
 
-# The PCM sample format to use. Possible values 
-# are F32, S32, S24, S24_3, S16. 
+# The PCM sample format to use. Possible values
+# are F32, S32, S24, S24_3, S16.
 # Change this value if you encounter errors like
 # "Alsa error PCM open ALSA function 'snd_pcm_hw_params_set_format' failed with error 'EINVAL: Invalid argument'"
 audio_format = "S16"
@@ -117,7 +117,9 @@ proxy = "http://proxy.example.org:8080"
 
 # The displayed device type in Spotify clients.
 # Can be unknown, computer, tablet, smartphone, speaker, t_v,
-# a_v_r (Audio/Video Receiver), s_t_b (Set-Top Box), and audio_dongle.
+# a_v_r (Audio/Video Receiver), s_t_b (Set-Top Box), audio_dongle,
+# game_console, cast_audio, cast_video, automobile, smartwatch, chromebook,
+# unknown_spotify, car_thing, observer and home_thing.
 device_type = "speaker"
 ```
 
@@ -127,7 +129,7 @@ device_type = "speaker"
 
   Spotifyd is able to advertise itself on the network without credentials. To enable this, you must omit / comment any `username` / `username_cmd` or `password` / `password_cmd` in the configuration. Spotifyd will receive an authentication blob from Spotify when you choose it from the devices list.
 
-  > __Note:__ If you choose to go with this, it is also recommended to omit the `cache_path` and `cache_directory` options. Otherwise the first user to connect to the service will have its authentication blob cached by the service and nobody else will be able to connect to the service without clearing the cache.
+  > **Note:** If you choose to go with this, it is also recommended to omit the `cache_path` and `cache_directory` options. Otherwise the first user to connect to the service will have its authentication blob cached by the service and nobody else will be able to connect to the service without clearing the cache.
 
   This way, a Spotifyd instance can also be made available to multiple users.
 
@@ -146,9 +148,9 @@ device_type = "speaker"
 
 - **`use_keyring`** config entry / **`--use-keyring`** CLI flag <!-- omit in toc -->
 
-  > __Note:__ If choosing the user's keyring to store login credentials, running spotifyd as a systemd _system service_ is no longer possible. A system wide service cannot access a specific user's keyring. In this case, make sure to run spotifyd as a systemd _user service_. See [systemd configuration](services/Systemd.md).
+  > **Note:** If choosing the user's keyring to store login credentials, running spotifyd as a systemd _system service_ is no longer possible. A system wide service cannot access a specific user's keyring. In this case, make sure to run spotifyd as a systemd _user service_. See [systemd configuration](services/Systemd.md).
 
-  This features leverages [Linux's DBus Secret Service API][secret-storage-specification] or native macOS keychain in order to forgo the need to store your password directly in the config file. To use it, compile with the `dbus_keyring` feature and set the `use-keyring` config entry to `true` or pass the `--use-keyring` CLI flag  during start to the daemon. Remove the `password` and/or `password_cmd` config entries.
+  This features leverages [Linux's DBus Secret Service API][secret-storage-specification] or native macOS keychain in order to forgo the need to store your password directly in the config file. To use it, compile with the `dbus_keyring` feature and set the `use-keyring` config entry to `true` or pass the `--use-keyring` CLI flag during start to the daemon. Remove the `password` and/or `password_cmd` config entries.
 
   Your keyring entry needs to have the following attributes set:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,28 +146,28 @@ static DEVICETYPE_VALUES: &[&str] = &[
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, StructOpt)]
 #[serde(rename_all = "snake_case")]
 pub enum DeviceType {
-    Unknown = 0,
-    Computer = 1,
-    Tablet = 2,
-    Smartphone = 3,
-    Speaker = 4,
+    Unknown,
+    Computer,
+    Tablet,
+    Smartphone,
+    Speaker,
     #[serde(rename = "t_v")]
-    Tv = 5,
+    Tv,
     #[serde(rename = "a_v_r")]
-    Avr = 6,
+    Avr,
     #[serde(rename = "s_t_b")]
-    Stb = 7,
-    AudioDongle = 8,
-    GameConsole = 9,
-    CastAudio = 10,
-    CastVideo = 11,
-    Automobile = 12,
-    Smartwatch = 13,
-    Chromebook = 14,
-    UnknownSpotify = 15,
-    CarThing = 16,
-    Observer = 17,
-    HomeThing = 18,
+    Stb,
+    AudioDongle,
+    GameConsole,
+    CastAudio,
+    CastVideo,
+    Automobile,
+    Smartwatch,
+    Chromebook,
+    UnknownSpotify,
+    CarThing,
+    Observer,
+    HomeThing,
 }
 
 impl From<LSDeviceType> for DeviceType {

--- a/src/config.rs
+++ b/src/config.rs
@@ -132,6 +132,14 @@ static DEVICETYPE_VALUES: &[&str] = &[
     "avr",
     "stb",
     "audiodongle",
+    "gameconsole",
+    "castaudio",
+    "castvideo",
+    "automobile",
+    "smartwatch",
+    "chromebook",
+    "carthing",
+    "homething",
 ];
 
 // Spotify's device type (copied from it's config.rs)
@@ -150,6 +158,16 @@ pub enum DeviceType {
     #[serde(rename = "s_t_b")]
     Stb = 7,
     AudioDongle = 8,
+    GameConsole = 9,
+    CastAudio = 10,
+    CastVideo = 11,
+    Automobile = 12,
+    Smartwatch = 13,
+    Chromebook = 14,
+    UnknownSpotify = 15,
+    CarThing = 16,
+    Observer = 17,
+    HomeThing = 18,
 }
 
 impl From<LSDeviceType> for DeviceType {
@@ -164,8 +182,16 @@ impl From<LSDeviceType> for DeviceType {
             LSDeviceType::Avr => DeviceType::Avr,
             LSDeviceType::Stb => DeviceType::Stb,
             LSDeviceType::AudioDongle => DeviceType::AudioDongle,
-            // TODO: Implement new LibreSpot device types in Spotifyd
-            _ => DeviceType::Unknown,
+            LSDeviceType::GameConsole => DeviceType::GameConsole,
+            LSDeviceType::CastAudio => DeviceType::CastAudio,
+            LSDeviceType::CastVideo => DeviceType::CastVideo,
+            LSDeviceType::Automobile => DeviceType::Automobile,
+            LSDeviceType::Smartwatch => DeviceType::Smartwatch,
+            LSDeviceType::Chromebook => DeviceType::Chromebook,
+            LSDeviceType::UnknownSpotify => DeviceType::UnknownSpotify,
+            LSDeviceType::CarThing => DeviceType::CarThing,
+            LSDeviceType::Observer => DeviceType::Observer,
+            LSDeviceType::HomeThing => DeviceType::HomeThing,
         }
     }
 }
@@ -182,6 +208,16 @@ impl From<&DeviceType> for LSDeviceType {
             DeviceType::Avr => LSDeviceType::Avr,
             DeviceType::Stb => LSDeviceType::Stb,
             DeviceType::AudioDongle => LSDeviceType::AudioDongle,
+            DeviceType::GameConsole => LSDeviceType::GameConsole,
+            DeviceType::CastAudio => LSDeviceType::CastAudio,
+            DeviceType::CastVideo => LSDeviceType::CastVideo,
+            DeviceType::Automobile => LSDeviceType::Automobile,
+            DeviceType::Smartwatch => LSDeviceType::Smartwatch,
+            DeviceType::Chromebook => LSDeviceType::Chromebook,
+            DeviceType::UnknownSpotify => LSDeviceType::UnknownSpotify,
+            DeviceType::CarThing => LSDeviceType::CarThing,
+            DeviceType::Observer => LSDeviceType::Observer,
+            DeviceType::HomeThing => LSDeviceType::HomeThing,
         }
     }
 }


### PR DESCRIPTION
`spotifyd` was lacking new device types (such as `automobile`, `gameconsole` etc.) introduced some time ago in `librespot`.