### PR TITLE
chore: use resolver v2 for correct bindgen feature

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,7 +70,9 @@ jobs:
         run: |
           sudo apt-get update
           # alsa_backend,rodio_backend and base deps
-          sudo apt-get install -y libasound2-dev libssl-dev libclang-dev clang
+          sudo apt-get install -y libasound2-dev libssl-dev
+          # potentially install bindgen dependencies
+          sudo apt-get install -y libclang-dev cmake
           # dbus_mpris
           sudo apt-get install -y libdbus-1-dev
           # pulseaudio_backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - revert default features to `alsa_backend` ([#1337])
+- do not require `bindgen` dependencies on supported systems ([#1340])
 
 [#1337]: https://github.com/Spotifyd/spotifyd/pull/1337
+[#1340]: https://github.com/Spotifyd/spotifyd/pull/1340
 
 ## [0.4.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "A Spotify daemon"
 repository = "https://github.com/Spotifyd/spotifyd"
 license = "GPL-3.0-only"
 version = "0.4.0"
+resolver = "2"
 rust-version = "1.82"
 
 [dependencies]
@@ -51,7 +52,7 @@ whoami = "1"
 [target."cfg(target_os = \"openbsd\")".dependencies]
 pledge = "0.4.2"
 
-[target.armv7-unknown-linux-gnueabihf.dependencies]
+[target."cfg(not(any(target_arch = \"aarch64\", target_arch = \"x86_64\")))".dependencies]
 aws-lc-rs = { version = "1.12.5", features = ["bindgen"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,17 +42,17 @@ time = { version = "0.3.37", default-features = false, features = ["formatting"]
 clap = { version = "4.5.23", features = ["derive"] }
 serde_ignored = "0.1.10"
 
-[target."cfg(unix)".dependencies]
+[target.'cfg(unix)'.dependencies]
 daemonize = "0.5"
 syslog = "7"
 
-[target."cfg(target_os = \"macos\")".dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
 whoami = "1"
 
-[target."cfg(target_os = \"openbsd\")".dependencies]
+[target.'cfg(target_os = "openbsd")'.dependencies]
 pledge = "0.4.2"
 
-[target."cfg(not(any(target_arch = \"aarch64\", target_arch = \"x86_64\")))".dependencies]
+[target.'cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))'.dependencies]
 aws-lc-rs = { version = "1.12.5", features = ["bindgen"] }
 
 [dev-dependencies]

--- a/Cross.toml
+++ b/Cross.toml
@@ -2,8 +2,10 @@
 pre-build = [
   "dpkg --add-architecture $CROSS_DEB_ARCH",
   "apt-get update",
+  # bindgen requirements
+  "apt-get install -y libclang-dev cmake",
   # alsa_backend,rodio_backend and base requirements
-  "apt-get install -y libasound2-dev:$CROSS_DEB_ARCH libssl-dev:$CROSS_DEB_ARCH libclang-10-dev clang-10",
+  "apt-get install -y libasound2-dev:$CROSS_DEB_ARCH libssl-dev:$CROSS_DEB_ARCH",
   # dbus_mpris
   "apt-get install -y libdbus-1-dev:$CROSS_DEB_ARCH",
   # pulseaudio_backend


### PR DESCRIPTION
Fixes #1334.

This fixes the selection of the `bindgen` feature, such that on most platforms, it should automatically choose the correct behaviour.