### PR TITLE
cd: fix linux build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,10 +69,13 @@ jobs:
         if: startsWith(matrix.runs_on, 'ubuntu') && matrix.target == ''
         run: |
           sudo apt-get update
+          # WORKAROUND: fix aws-lc-sys compiler bug failure
+          sudo apt-get remove -y gcc-9
+          sudo apt-get install -y gcc-10
+          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc-10" >> "$GITHUB_ENV"
+          echo "CC=gcc-10" >> "$GITHUB_ENV"
           # alsa_backend,rodio_backend and base deps
           sudo apt-get install -y libasound2-dev libssl-dev
-          # potentially install bindgen dependencies
-          sudo apt-get install -y libclang-dev cmake
           # dbus_mpris
           sudo apt-get install -y libdbus-1-dev
           # pulseaudio_backend

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -91,7 +91,7 @@ jobs:
         if: matrix.target != ''
         uses: houseabsolute/actions-rust-cross@v1
         with:
-          cross-version: 49338b1 # currently needed (check again if cross version > 0.2.5)
+          cross-version: 36c0d78 # currently needed (check again if cross version > 0.2.5)
           command: build
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}


### PR DESCRIPTION
This fixes the cd issue by resetting the cross cache and working around a `gcc-9` issue.

Fixes #1341 (again).