### PR TITLE
Update librespot to fix #1356 / #1358 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,7 +215,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -580,6 +586,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +891,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.8.9",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,8 +1056,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -1050,20 +1077,23 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "governor"
-version = "0.6.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
 dependencies = [
  "cfg-if",
- "futures",
+ "futures-sink",
  "futures-timer",
+ "futures-util",
+ "getrandom 0.3.1",
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",
  "portable-atomic",
- "rand 0.8.5",
+ "rand 0.9.0",
  "smallvec",
  "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -1307,6 +1337,7 @@ dependencies = [
  "tokio-rustls 0.25.0",
  "tower-service",
  "webpki",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1340,6 +1371,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.25.0",
  "tower-service",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1359,6 +1391,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1588,6 +1621,25 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1845,9 +1897,8 @@ dependencies = [
 
 [[package]]
 name = "librespot-audio"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e07566fe7553042936c61bbdd9bedb524114a904aa7f9738e266c641468bab8"
+version = "0.6.0-dev"
+source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "aes",
  "bytes",
@@ -1860,17 +1911,15 @@ dependencies = [
  "log",
  "parking_lot",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
 [[package]]
 name = "librespot-connect"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce3a5634669ce051a425cff5437a474831111df045fd5a2bb37fabe316fa60"
+version = "0.6.0-dev"
+source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
- "form_urlencoded",
  "futures-util",
  "librespot-core",
  "librespot-playback",
@@ -1878,24 +1927,24 @@ dependencies = [
  "log",
  "protobuf",
  "rand 0.8.5",
- "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
+ "uuid",
 ]
 
 [[package]]
 name = "librespot-core"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4c76303efcf949a59f9380220ca420c4d72fa32dbb3641a0079f429cc5e44e7"
+version = "0.6.0-dev"
+source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "aes",
  "base64 0.22.1",
  "byteorder",
  "bytes",
  "data-encoding",
+ "flate2",
  "form_urlencoded",
  "futures-core",
  "futures-util",
@@ -1922,6 +1971,7 @@ dependencies = [
  "pin-project-lite",
  "priority-queue",
  "protobuf",
+ "protobuf-json-mapping",
  "quick-xml",
  "rand 0.8.5",
  "rsa",
@@ -1930,7 +1980,7 @@ dependencies = [
  "sha1",
  "shannon",
  "sysinfo",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-stream",
@@ -1943,9 +1993,8 @@ dependencies = [
 
 [[package]]
 name = "librespot-discovery"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a952d28c775562b9b6039102c0e3a834cb31157fccb2f2a68a26dc4397fea8"
+version = "0.6.0-dev"
+source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "aes",
  "base64 0.22.1",
@@ -1965,15 +2014,14 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
 [[package]]
 name = "librespot-metadata"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf6d5c46a401b1dd3e062ebdce959aa694bbae1039841756545d2e9c4f8be5f"
+version = "0.6.0-dev"
+source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1983,27 +2031,26 @@ dependencies = [
  "protobuf",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "uuid",
 ]
 
 [[package]]
 name = "librespot-oauth"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dcad779aa6c3b442e493e2a40ca83a5c5fcf38a65c05b026c3587bd4f8d14f"
+version = "0.6.0-dev"
+source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "log",
  "oauth2",
- "thiserror 1.0.69",
+ "open",
+ "thiserror 2.0.12",
  "url",
 ]
 
 [[package]]
 name = "librespot-playback"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed1f776a04c8c9275407f8d4df034f2615ea729ec6c6d0fa69f423fc571df64"
+version = "0.6.0-dev"
+source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "alsa",
  "cpal",
@@ -2015,22 +2062,22 @@ dependencies = [
  "librespot-metadata",
  "log",
  "parking_lot",
+ "portable-atomic",
  "portaudio-rs",
  "rand 0.8.5",
  "rand_distr",
  "rodio",
  "shell-words",
  "symphonia",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
 name = "librespot-protocol"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80802f52b5a1b3a2157454e6aca483a627fbf7b942e0a5fea037ebf3ed8b0546"
+version = "0.6.0-dev"
+source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "protobuf",
  "protobuf-codegen",
@@ -2104,6 +2151,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -2350,6 +2406,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
+name = "open"
+version = "5.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,6 +2465,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pbkdf2"
@@ -2530,7 +2603,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2599,6 +2672,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf-json-mapping"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d6e4be637b310d8a5c02fa195243328e2d97fa7df1127a27281ef1187fcb1d"
+dependencies = [
+ "protobuf",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "protobuf-parse"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
  "serde",
@@ -2661,7 +2745,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2798,7 +2882,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -2818,12 +2902,11 @@ dependencies = [
 
 [[package]]
 name = "rodio"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb"
+checksum = "e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1"
 dependencies = [
  "cpal",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3468,15 +3551,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.31.4"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
 dependencies = [
  "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "windows 0.57.0",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -3714,6 +3797,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4078,6 +4162,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4092,6 +4186,24 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"
@@ -4168,16 +4280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4194,40 +4296,6 @@ checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
  "windows-result",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4525,32 +4593,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "zerocopy-derive 0.8.23",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "librespot-audio"
 version = "0.6.0-dev"
-source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
+source = "git+https://github.com/librespot-org/librespot.git?rev=ba3d501#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "aes",
  "bytes",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "librespot-connect"
 version = "0.6.0-dev"
-source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
+source = "git+https://github.com/librespot-org/librespot.git?rev=ba3d501#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "futures-util",
  "librespot-core",
@@ -1937,7 +1937,7 @@ dependencies = [
 [[package]]
 name = "librespot-core"
 version = "0.6.0-dev"
-source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
+source = "git+https://github.com/librespot-org/librespot.git?rev=ba3d501#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "aes",
  "base64 0.22.1",
@@ -1994,7 +1994,7 @@ dependencies = [
 [[package]]
 name = "librespot-discovery"
 version = "0.6.0-dev"
-source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
+source = "git+https://github.com/librespot-org/librespot.git?rev=ba3d501#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "aes",
  "base64 0.22.1",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "librespot-metadata"
 version = "0.6.0-dev"
-source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
+source = "git+https://github.com/librespot-org/librespot.git?rev=ba3d501#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "librespot-oauth"
 version = "0.6.0-dev"
-source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
+source = "git+https://github.com/librespot-org/librespot.git?rev=ba3d501#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "log",
  "oauth2",
@@ -2050,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "librespot-playback"
 version = "0.6.0-dev"
-source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
+source = "git+https://github.com/librespot-org/librespot.git?rev=ba3d501#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "alsa",
  "cpal",
@@ -2077,7 +2077,7 @@ dependencies = [
 [[package]]
 name = "librespot-protocol"
 version = "0.6.0-dev"
-source = "git+https://github.com/librespot-org/librespot.git?branch=dev#ba3d501b08345aadf207d09b3a0713853228ba64"
+source = "git+https://github.com/librespot-org/librespot.git?rev=ba3d501#ba3d501b08345aadf207d09b3a0713853228ba64"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ sha-1 = "0.10"
 tokio = {version = "1.26.0", features = ["signal", "rt-multi-thread", "process", "io-std"] }
 tokio-stream = "0.1.7"
 url = "2.2.2"
-librespot-audio = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev', default-features = false }
-librespot-playback = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev', default-features = false }
-librespot-core = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev' }
-librespot-discovery = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev' }
-librespot-connect = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev' }
-librespot-metadata = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev' }
-librespot-protocol = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev' }
-librespot-oauth = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev' }
+librespot-audio = { git = 'https://github.com/librespot-org/librespot.git', rev = 'ba3d501', default-features = false }
+librespot-playback = { git = 'https://github.com/librespot-org/librespot.git', rev = 'ba3d501', default-features = false }
+librespot-core = { git = 'https://github.com/librespot-org/librespot.git', rev = 'ba3d501' }
+librespot-discovery = { git = 'https://github.com/librespot-org/librespot.git', rev = 'ba3d501' }
+librespot-connect = { git = 'https://github.com/librespot-org/librespot.git', rev = 'ba3d501' }
+librespot-metadata = { git = 'https://github.com/librespot-org/librespot.git', rev = 'ba3d501' }
+librespot-protocol = { git = 'https://github.com/librespot-org/librespot.git', rev = 'ba3d501' }
+librespot-oauth = { git = 'https://github.com/librespot-org/librespot.git', rev = 'ba3d501' }
 toml = "0.8.19"
 color-eyre = "0.6"
 directories = "6.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ sha-1 = "0.10"
 tokio = {version = "1.26.0", features = ["signal", "rt-multi-thread", "process", "io-std"] }
 tokio-stream = "0.1.7"
 url = "2.2.2"
-librespot-audio = { version = "0.6", default-features = false }
-librespot-playback = { version = "0.6", default-features = false }
-librespot-core = "0.6"
-librespot-discovery = "0.6"
-librespot-connect = "0.6"
-librespot-metadata = "0.6"
-librespot-protocol = "0.6"
-librespot-oauth = "0.6"
+librespot-audio = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev', default-features = false }
+librespot-playback = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev', default-features = false }
+librespot-core = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev' }
+librespot-discovery = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev' }
+librespot-connect = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev' }
+librespot-metadata = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev' }
+librespot-protocol = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev' }
+librespot-oauth = { git = 'https://github.com/librespot-org/librespot.git', branch = 'dev' }
 toml = "0.8.19"
 color-eyre = "0.6"
 directories = "6.0.0"

--- a/src/alsa_mixer.rs
+++ b/src/alsa_mixer.rs
@@ -36,12 +36,12 @@ impl AlsaMixer {
 }
 
 impl Mixer for AlsaMixer {
-    fn open(_: MixerConfig) -> AlsaMixer {
-        AlsaMixer {
+    fn open(_: MixerConfig) -> Result<Self, librespot_core::Error> {
+        Ok(AlsaMixer {
             device: "default".to_string(),
             mixer: "Master".to_string(),
             linear_scaling: false,
-        }
+        })
     }
 
     fn volume(&self) -> u16 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,7 +69,6 @@ pub enum DeviceType {
     UnknownSpotify,
     CarThing,
     Observer,
-    HomeThing,
 }
 
 impl From<DeviceType> for LSDeviceType {
@@ -93,7 +92,6 @@ impl From<DeviceType> for LSDeviceType {
             DeviceType::UnknownSpotify => LSDeviceType::UnknownSpotify,
             DeviceType::CarThing => LSDeviceType::CarThing,
             DeviceType::Observer => LSDeviceType::Observer,
-            DeviceType::HomeThing => LSDeviceType::HomeThing,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -594,7 +594,7 @@ impl SharedConfigValues {
 }
 
 pub(crate) fn get_config_file() -> Option<PathBuf> {
-    let etc_conf = format!("/etc/{}", CONFIG_FILE_NAME);
+    let etc_conf = format!("/etc/{CONFIG_FILE_NAME}");
     let dirs = directories::ProjectDirs::from("", "", "spotifyd")?;
     let mut path = dirs.config_dir().to_path_buf();
     path.push(CONFIG_FILE_NAME);

--- a/src/error.rs
+++ b/src/error.rs
@@ -89,17 +89,13 @@ impl Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ErrorKind::Subprocess { cmd, msg, shell } => match msg {
-                Message::None => write!(f, "Failed to execute {:?} using {:?}.", cmd, shell),
-                Message::Error(ref e) => write!(
-                    f,
-                    "Failed to execute {:?} using {:?}. Error: {}",
-                    cmd, shell, e
-                ),
-                Message::String(ref s) => write!(
-                    f,
-                    "Failed to execute {:?} using {:?}. Error: {}",
-                    cmd, shell, s
-                ),
+                Message::None => write!(f, "Failed to execute {cmd:?} using {shell:?}."),
+                Message::Error(ref e) => {
+                    write!(f, "Failed to execute {cmd:?} using {shell:?}. Error: {e}")
+                }
+                Message::String(ref s) => {
+                    write!(f, "Failed to execute {cmd:?} using {shell:?}. Error: {s}")
+                }
             },
             ErrorKind::NormalisationPregainInvalid => write!(
                 f,

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -14,7 +14,7 @@ use futures::{
     stream::Peekable,
     Future, FutureExt, StreamExt,
 };
-use librespot_connect::{config::ConnectConfig, spirc::Spirc};
+use librespot_connect::{ConnectConfig, Spirc};
 use librespot_core::{
     authentication::Credentials, cache::Cache, config::DeviceType, session::Session, Error,
     SessionConfig,
@@ -125,8 +125,9 @@ impl MainLoop {
                     name: self.device_name.clone(),
                     device_type: self.device_type,
                     is_group: false,
-                    initial_volume: self.initial_volume,
-                    has_volume_ctrl: self.has_volume_ctrl,
+                    initial_volume: self.initial_volume.unwrap_or(0),
+                    disable_volume: !self.has_volume_ctrl,
+                    volume_steps: 64,
                 },
                 session.clone(),
                 creds.clone(),

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -125,7 +125,7 @@ impl MainLoop {
                     name: self.device_name.clone(),
                     device_type: self.device_type,
                     is_group: false,
-                    initial_volume: self.initial_volume.unwrap_or(0),
+                    initial_volume: self.initial_volume.unwrap_or(50),
                     disable_volume: !self.has_volume_ctrl,
                     volume_steps: 64,
                 },

--- a/src/no_mixer.rs
+++ b/src/no_mixer.rs
@@ -3,8 +3,8 @@ use librespot_playback::mixer::{Mixer, MixerConfig};
 pub struct NoMixer;
 
 impl Mixer for NoMixer {
-    fn open(_: MixerConfig) -> NoMixer {
-        NoMixer {}
+    fn open(_: MixerConfig) -> Result<NoMixer, librespot_core::Error> {
+        Ok(NoMixer {})
     }
 
     fn volume(&self) -> u16 {

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -4,6 +4,7 @@ use color_eyre::{
 };
 use librespot_core::SessionConfig;
 use librespot_core::{authentication::Credentials, Session};
+use librespot_oauth::OAuthClientBuilder;
 use log::info;
 use tokio::runtime::Runtime;
 
@@ -55,12 +56,17 @@ pub(crate) fn run_oauth(mut cli_config: CliConfig, oauth_port: u16) -> eyre::Res
         ..Default::default()
     };
 
-    let token = librespot_oauth::get_access_token(
+    let oauth_client = OAuthClientBuilder::new(
         &session_config.client_id,
         &format!("http://127.0.0.1:{oauth_port}/login"),
         OAUTH_SCOPES.to_vec(),
     )
-    .wrap_err("token retrieval failed")?;
+    .build()
+    .wrap_err("failed to build OAuth client")?;
+
+    let token = oauth_client
+        .get_access_token()
+        .wrap_err("token retrieval failed")?;
 
     let creds = Credentials::with_access_token(token.access_token);
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -179,14 +179,10 @@ pub(crate) fn spawn_program_on_event(
             env.insert("PLAYER_EVENT", "shuffle_changed".to_string());
             env.insert("SHUFFLE", shuffle.to_string());
         }
-        PlayerEvent::RepeatChanged { repeat } => {
+        PlayerEvent::RepeatChanged { context, track } => {
             env.insert("PLAYER_EVENT", "repeat_changed".to_string());
-            let val = match repeat {
-                true => "all",
-                false => "none",
-            }
-            .to_string();
-            env.insert("REPEAT", val);
+            env.insert("REPEAT", format!("{:?}", context));
+            env.insert("REPEAT_TRACK", format!("{:?}", track));
         }
         PlayerEvent::AutoPlayChanged { auto_play } => {
             env.insert("PLAYER_EVENT", "autoplay_changed".to_string());
@@ -196,6 +192,7 @@ pub(crate) fn spawn_program_on_event(
             env.insert("PLAYER_EVENT", "filterexplicit_changed".to_string());
             env.insert("FILTEREXPLICIT", filter.to_string());
         }
+        PlayerEvent::PositionChanged { .. } => todo!(),
     }
     spawn_program(shell, cmd, env)
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -181,8 +181,13 @@ pub(crate) fn spawn_program_on_event(
         }
         PlayerEvent::RepeatChanged { context, track } => {
             env.insert("PLAYER_EVENT", "repeat_changed".to_string());
-            env.insert("REPEAT", format!("{:?}", context));
-            env.insert("REPEAT_TRACK", format!("{:?}", track));
+            let val = match (context, track) {
+                (_, true) => "track",
+                (true, false) => "all",
+                (false, false) => "none",
+            }
+            .to_string();
+            env.insert("REPEAT", val);
         }
         PlayerEvent::AutoPlayChanged { auto_play } => {
             env.insert("PLAYER_EVENT", "autoplay_changed".to_string());
@@ -192,7 +197,7 @@ pub(crate) fn spawn_program_on_event(
             env.insert("PLAYER_EVENT", "filterexplicit_changed".to_string());
             env.insert("FILTEREXPLICIT", filter.to_string());
         }
-        PlayerEvent::PositionChanged { .. } => todo!(),
+        PlayerEvent::PositionChanged { .. } => unreachable!("this event is not enabled"),
     }
     spawn_program(shell, cmd, env)
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -44,7 +44,7 @@ pub(crate) fn initial_state(
             }
             _ => {
                 info!("Using software volume controller.");
-                Arc::new(mixer::softmixer::SoftMixer::open(MixerConfig::default()))
+                Arc::new(mixer::softmixer::SoftMixer::open(MixerConfig::default())?)
             }
         }
     };


### PR DESCRIPTION
As the title says, since spotify broke things with an api change as referenced in #1356 and  #1358, a fix was implemented in librespot but it hasn't been versioned yet, so this pulls the commit that fixed it and I've done the minimum of what was needed to get things working considering the changes in librespot between 0.6 and now. 
I'm far from a rust dev nor am I familiar with the inner workings of this project, I basically just brute forced based on compiler errors until it compiled, I can confirm it does build and launch, and the issue with the 500 errors is resolved without any host file tweaking.
 I'm not expecting that this'll get merged, just getting the ball rolling.