### PR TITLE
Remove extraneous deps for .deb package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ rodio_backend = ["librespot-playback/rodio-backend"]
 rodiojack_backend = ["librespot-playback/rodiojack-backend"]
 
 [package.metadata.deb]
-depends = "$auto, systemd, pulseaudio"
+depends = "$auto"
 features = ["pulseaudio_backend", "dbus_mpris"]
 assets = [
     ["target/release/spotifyd", "usr/bin/", "755"],


### PR DESCRIPTION
The auto detection works fine and depends on everything that should be depended on afaict. Actual pulseaudio should not be depended on directly, only `libpulse0` (auto-detected) which is provided by both pulseaudio and pipewire.

Fixes #1346 