### PR TITLE
mpris: fix mpris interface not reappearing

### DIFF
--- a/src/dbus_mpris.rs
+++ b/src/dbus_mpris.rs
@@ -577,6 +577,7 @@ async fn create_dbus_server(
                         cr.remove::<()>(&CONTROLS_PATH.into());
                         spirc = None;
                         session = None;
+                        cur_conn = None;
                     }
                 }
             }


### PR DESCRIPTION
Since we previously didn't reset this variable, the MPRIS interface was successfully removed, but never republished on the bus. I hope this fixes it.

Fixes https://github.com/orgs/Spotifyd/discussions/1383.