### PR TITLE
ci: build aarch64 natively

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,6 +27,9 @@ jobs:
             runs_on: macos-15
           - os: linux
             runs_on: ubuntu-22.04
+          - os: linux
+            arch: aarch64
+            runs_on: ubuntu-22.04-arm
           # DBus configuration
           - artifact_type: slim
             dbus: ''
@@ -35,9 +38,6 @@ jobs:
           - artifact_type: full
             dbus: dbus_mpris
           # Cross Compilation Targets
-          - os: linux
-            arch: aarch64
-            target: aarch64-unknown-linux-gnu
           - os: linux
             arch: armv7
             target: armv7-unknown-linux-gnueabihf


### PR DESCRIPTION
The new'ish GitHub hosted ARM runners allow native `aarch64` builds. `armv7l` would at least require a `armhf` toolchain, leaving it untouched for now.

Builds succeed on my fork: https://github.com/MichaIng/spotifyd/actions/runs/20681743289

I was actually trying to solve the fact that ARM builds are linked against libssl1.1, despite Ubuntu 22.04 build runners, which ship libssl3 by default. This PR solves this for `aarch64` builds implicitly, <s>since the issue seems to be old cache entries pulled by the `cross` action.

To trigger `armv7l` builds that work on modern OS versions (Debian 12 Bookworm, Ubuntu 22.04 Jammy, and above), it looks like clearing this repo's Actions cache would do, or alternatively bumping the `cross-version` commit hash, which should invalidate the existing cache entries.</s> EDIT: Nope, sadly this is the issue, even with latest `cross`: https://github.com/cross-rs/cross/blob/main/docker/Dockerfile.armv7-unknown-linux-gnueabihf#L1

This makes is pretty unusable, IMO. The last distro versions with libssl1.1 are 5 or more years old, and installing outdated crypto-libraries from 3rd party sources (or own builds) is no suitable solution for the masses 🤔. There is a PR open, to bump the images to Ubuntu 24.04: https://github.com/cross-rs/cross/pull/1580
I'll try builds using the commit of this PR. EDIT2: This does not work since `cross` pulls the images from ghcr, and does not build them from the Dockerfile's.