### PR TITLE
ci: add armv6 (Raspberry Pi B/Zero) build support

### DIFF
--- a/.github/Dockerfile.armv6
+++ b/.github/Dockerfile.armv6
@@ -1,0 +1,73 @@
+# syntax=docker/dockerfile:1
+
+# ── Builder base images ────────────────────────────────────────────────────────
+# amd64: Debian Trixie (build natif)
+# arm64/arm: RaspiOS (Bookworm), exécuté nativement via QEMU binfmt_misc —
+#   pas de cross-compiler nécessaire, même pour CGO/bindgen
+FROM debian:trixie-slim       AS base-amd64
+FROM vascoguita/raspios:arm64 AS base-arm64
+FROM vascoguita/raspios:armhf AS base-arm
+
+# ── Builder ───────────────────────────────────────────────────────────────────
+ARG TARGETARCH
+FROM base-${TARGETARCH} AS builder
+
+ARG TARGETARCH
+ARG TARGETVARIANT
+# Fonctionnalités à compiler. Valeur par défaut : slim armv6 (alsa seul, sans
+# pulseaudio/dbus pour réduire les dépendances sur Pi Zero)
+ARG FEATURES="--no-default-features --features alsa_backend"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    gcc \
+    libc6-dev \
+    # aws-lc-rs (bindgen) — requis sur les cibles non-x86_64/aarch64
+    libclang-dev \
+    cmake \
+    pkg-config \
+    # alsa_backend + base
+    libasound2-dev \
+    libssl-dev \
+    # dbus_mpris (désactivé par défaut pour armv6 mais gardé disponible)
+    libdbus-1-dev \
+    # pulseaudio_backend (idem)
+    libpulse-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Installe Rust en forçant le host triple correct.
+# QEMU peut rapporter armv7 même sur un container armv6 — on corrige ça manuellement.
+RUN set -eux; \
+    case "${TARGETARCH}${TARGETVARIANT}" in \
+        armv6)   RUST_HOST="arm-unknown-linux-gnueabihf"    ;; \
+        armv7)   RUST_HOST="armv7-unknown-linux-gnueabihf"  ;; \
+        arm64)   RUST_HOST="aarch64-unknown-linux-gnu"      ;; \
+        amd64)   RUST_HOST="x86_64-unknown-linux-gnu"       ;; \
+        *)       RUST_HOST=""                               ;; \
+    esac; \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --default-toolchain stable --profile minimal \
+        ${RUST_HOST:+--default-host "$RUST_HOST"}
+ENV PATH="/root/.cargo/bin:$PATH"
+
+# aws-lc-rs utilise bindgen en mode natif (pas de cross-compilation)
+ENV AWS_LC_SYS_BINDGEN=1
+
+WORKDIR /build
+
+COPY Cargo.lock Cargo.toml ./
+COPY src/ src/
+
+# Le cache cargo persiste entre les builds — changer FEATURES ne recompile
+# pas toutes les dépendances depuis zéro.
+# shellcheck disable=SC2086  # $FEATURES doit être word-split intentionnellement
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo build --locked --release $FEATURES && \
+    cp target/release/spotifyd /spotifyd
+
+# ── Binary export : extrait via --output type=local ───────────────────────────
+FROM scratch AS export
+COPY --from=builder /spotifyd /spotifyd

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos, linux]
-        arch: [x86_64, aarch64, armv7]
+        arch: [x86_64, aarch64, armv7, armv6]
         rust: [stable]
         artifact_type: ['slim', 'default', 'full']  # The build strategy will build all types for each OS specified
         include:
@@ -30,6 +30,9 @@ jobs:
           - os: linux
             arch: aarch64
             runs_on: ubuntu-22.04-arm
+          - os: linux
+            arch: armv6
+            runs_on: ubuntu-latest
           # DBus configuration
           - artifact_type: slim
             dbus: ''
@@ -59,6 +62,8 @@ jobs:
             artifact_type: 'full'
           - os: macos
             arch: armv7
+          - os: macos
+            arch: armv6
     steps:
       - name: Checking out sources
         uses: actions/checkout@v4
@@ -66,7 +71,7 @@ jobs:
         if: matrix.os == 'macos'
         run: brew install dbus portaudio
       - name: Installing needed Ubuntu dependencies
-        if: startsWith(matrix.runs_on, 'ubuntu') && matrix.target == ''
+        if: startsWith(matrix.runs_on, 'ubuntu') && matrix.target == '' && matrix.arch != 'armv6'
         run: |
           sudo apt-get update
           # WORKAROUND: fix aws-lc-sys compiler bug failure
@@ -87,7 +92,7 @@ jobs:
           features="--no-default-features --features ${{ matrix.dbus }},${{ matrix.audio_backends }}"
           echo CARGO_ARGS="--locked --release $features" | tee -a "$GITHUB_ENV"
       - name: Build (using cargo)
-        if: matrix.target == ''
+        if: matrix.target == '' && matrix.arch != 'armv6'
         run: |
            cargo +${{ matrix.rust }} build $CARGO_ARGS
       - name: Build (using cross)
@@ -99,6 +104,26 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           args: $CARGO_ARGS
+      - name: Set up QEMU
+        if: matrix.arch == 'armv6'
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        if: matrix.arch == 'armv6'
+        uses: docker/setup-buildx-action@v3
+      - name: Build (using docker buildx for armv6)
+        if: matrix.arch == 'armv6'
+        run: |
+          docker buildx build \
+            --platform linux/arm/v6 \
+            --file .github/Dockerfile.armv6 \
+            --target export \
+            --output type=local,dest=./armv6-out \
+            --cache-from type=gha,scope=armv6-${{ matrix.artifact_type }} \
+            --cache-to type=gha,scope=armv6-${{ matrix.artifact_type }},mode=max \
+            --build-arg FEATURES="--no-default-features --features ${{ matrix.dbus }},${{ matrix.audio_backends }}" \
+            .
+          mkdir -p target/release
+          cp ./armv6-out/spotifyd target/release/spotifyd
       - name: Uploading artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ tags
 .vscode
 # Windows logs
 *.log
+
+# docker cross build
+dist/


### PR DESCRIPTION
Cross-compilation via `cross` doesn't work for armv6 due to C dependencies (alsa, dbus, pulseaudio) and bindgen (aws-lc-rs). Instead, build natively under QEMU using a RaspiOS container, forcing the correct rustup host triple (arm-unknown-linux-gnueabihf) since QEMU reports armv7 by default.

- Add .github/Dockerfile.armv6 for QEMU-native builds
- Add armv6 to the CD matrix (linux only, slim/default/full)
- Use docker buildx with GHA layer cache in the CD workflow