### PR TITLE
WIP: making sure a single daemon instance is being executed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libdbus-sys"
@@ -2077,6 +2083,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -3250,6 +3268,7 @@ dependencies = [
  "librespot-playback",
  "librespot-protocol",
  "log",
+ "nix",
  "pledge",
  "serde",
  "serde_ignored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ clap = { version = "4.5.23", features = ["derive"] }
 serde_ignored = "0.1.10"
 
 [target.'cfg(unix)'.dependencies]
+nix = { version = "0.31.2", features = ["fs"] }
 daemonize = "0.5"
 syslog = "7"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,14 @@ use config::ExecutionMode;
 use daemonize::Daemonize;
 use fern::colors::ColoredLevelConfig;
 use log::{LevelFilter, info, trace};
+#[cfg(unix)]
+use nix::fcntl::{Flock, FlockArg};
 use oauth::run_oauth;
 #[cfg(target_os = "openbsd")]
 use pledge::pledge;
 #[cfg(windows)]
 use std::fs;
+use std::fs::File;
 use tokio::runtime::Runtime;
 
 #[cfg(feature = "alsa_backend")]
@@ -124,6 +127,7 @@ fn main() -> eyre::Result<()> {
 
 fn run_daemon(mut cli_config: CliConfig) -> eyre::Result<()> {
     let is_daemon = !cli_config.no_daemon;
+    let mut _single_daemon_lock: Flock<File>;
 
     let log_target = if is_daemon {
         #[cfg(unix)]
@@ -164,6 +168,18 @@ fn run_daemon(mut cli_config: CliConfig) -> eyre::Result<()> {
 
         #[cfg(unix)]
         {
+            _single_daemon_lock = match Flock::lock(
+                File::create("/tmp/spotifyd-daemon-lock")?,
+                FlockArg::LockExclusiveNonblock,
+            ) {
+                Ok(l) => l,
+                Err(e) => {
+                    return Err(e.1).wrap_err(
+                        "Could not acquire lock, is there another daemon instance running ?",
+                    );
+                }
+            };
+
             let mut daemonize = Daemonize::new();
             if let Some(pid) = internal_config.pid.as_ref() {
                 daemonize = daemonize.pid_file(pid);


### PR DESCRIPTION
Hi,

I often forget if I have a running spotifyd instance or not, and also having a single daemon running feels more correct.

Assuming this is a feature interesting enough to be merged, questions: 

1 - Would the path for the lock file need to exist in the cfg ? And be configurable ? 
2 - Would it be necessary to have another cmd line option? e.g. --single-daemon
3 - It's the first time I write Rust, still need to figure out how to add a test for this.
3 - I don't have a Windows machine, have no idea how to test it there