### PR TITLE
ci: add riscv64 build support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ on:
       - master
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [macos, linux]
-        arch: [x86_64, aarch64, armv7]
+        arch: [x86_64, aarch64, armv7, riscv64]
         rust: [stable]
         artifact_type: ['slim', 'default', 'full']  # The build strategy will build all types for each OS specified
         include:
@@ -42,6 +42,9 @@ jobs:
           - os: linux
             arch: armv7
             target: armv7-unknown-linux-gnueabihf
+          - os: linux
+            arch: riscv64
+            target: riscv64gc-unknown-linux-gnu
           # Audio backend configuration: Linux
           - os: linux
             artifact_type: slim
@@ -60,9 +63,11 @@ jobs:
             artifact_type: 'full'
           - os: macos
             arch: armv7
+          - os: macos
+            arch: riscv64
     steps:
       - name: Checking out sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Installing needed macOS dependencies
         if: matrix.os == 'macos'
         run: brew install dbus portaudio
@@ -95,13 +100,13 @@ jobs:
         if: matrix.target != ''
         uses: houseabsolute/actions-rust-cross@v1
         with:
-          cross-version: baf457e # currently needed (check again if cross version > 0.2.5)
+          cross-version: 64b5bb4 # currently needed (check again if cross version > 0.2.5)
           command: build
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           args: $CARGO_ARGS
       - name: Uploading artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: spotifyd-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.artifact_type }}
           path: target/${{ matrix.target }}/release/spotifyd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Checking out sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v7
       - name: Installing rustfmt
         run: rustup component add rustfmt
       - name: Running rustfmt
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get install -y -qq libasound2-dev libssl-dev libpulse-dev libdbus-1-dev portaudio19-dev
 
       - name: Checking out sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v7
       - name: Installing clippy
         run: rustup component add clippy
       - name: Linting project
@@ -80,7 +80,7 @@ jobs:
           sudo apt-get install -y -qq libasound2-dev libssl-dev libpulse-dev libdbus-1-dev
 
       - name: Checking out sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v7
       - name: Checking Rust code
         uses: actions-rs/cargo@v1
         with:

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,7 +1,10 @@
 [build]
 pre-build = [
+  "sed -i \"s/arm64 armhf/$CROSS_DEB_ARCH/\" /etc/apt/sources.list.d/ubuntu.sources",
   "dpkg --add-architecture $CROSS_DEB_ARCH",
   "apt-get update",
+  # binfmt support since some packages' postinst scripts call target arch binaries
+  "apt-get install -y qemu-user-static binfmt-support",
   # bindgen requirements
   "apt-get install -y libclang-dev cmake",
   # alsa_backend,rodio_backend and base requirements
@@ -15,4 +18,7 @@ pre-build = [
 ]
 
 [target.armv7-unknown-linux-gnueabihf]
+image = ":edge" # needed, since dbus and pulse dependencies on older ubuntu versions are messy
+
+[target.riscv64gc-unknown-linux-gnu]
 image = ":edge" # needed, since dbus and pulse dependencies on older ubuntu versions are messy


### PR DESCRIPTION
This also raises the `cross-rs` version to the currently latest commit, which fixes support for `libssl3` and other recent library versions (usually implicit for riscv64 compatible distro versions), switching to Ubuntu 24.04 build runners. This as well solves #1389 for ARMv7 builds.

The added `workflow_dispatch:` was for easier testing on my fork, but might come in handy for you as well? So you can trigger CD manually from GitHub Actions GUI (without triggering a release).

I also raised the official actions versions, since they emit already warnings about outdated and soon unsupported Node requirements.

The `sed -i "s/arm64 armhf/$CROSS_DEB_ARCH/" /etc/apt/sources.list.d/ubuntu.sources` can be dropped after https://github.com/cross-rs/cross/pull/1785.

Installing QEMU + binfmt here does not seem to be an intentionally necessary step either. I am discussing this at https://github.com/cross-rs/cross/issues/1784.

#1400 drops the use of `cross-rs` entirely. With `trixie-slim` images, this works for `riscv64` the same way. But it has to be noted that builds via QEMU-emulation are significantly slower than cross-compiling. The individual builds via `cross-rs` took 5 minutes on my fork: https://github.com/MichaIng/spotifyd/actions/runs/28552458687
Would be interesting to compare, to evaluate whether using QEMU-emulation for 32-bit ARM and RISC-V make sense, or whether it should be done for `armv6` only, not supported by `cross-rs`.