### PR TITLE
mainloop: don't panic when discovery stops without credentials

### DIFF
--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -4,7 +4,10 @@ use crate::config::{DBusType, MprisConfig};
 use crate::dbus_mpris::DbusServer;
 use crate::process::spawn_program_on_event;
 use crate::utils::Backoff;
-use color_eyre::eyre::{self, Context};
+use color_eyre::{
+    Section,
+    eyre::{self, Context, eyre},
+};
 use futures::future::Either;
 #[cfg(not(feature = "dbus_mpris"))]
 use futures::future::Pending;
@@ -15,8 +18,7 @@ use futures::{
 };
 use librespot_connect::{ConnectConfig, Spirc};
 use librespot_core::{
-    Error, SessionConfig, authentication::Credentials, cache::Cache, config::DeviceType,
-    session::Session,
+    SessionConfig, authentication::Credentials, cache::Cache, config::DeviceType, session::Session,
 };
 use librespot_discovery::Discovery;
 use librespot_playback::{
@@ -41,7 +43,7 @@ pub(crate) enum CredentialsProvider {
 }
 
 impl CredentialsProvider {
-    async fn get_credentials(&mut self) -> Credentials {
+    async fn get_credentials(&mut self) -> eyre::Result<Credentials> {
         match self {
             CredentialsProvider::Discovery {
                 stream,
@@ -49,12 +51,20 @@ impl CredentialsProvider {
             } => {
                 let new_creds = match last_credentials.take() {
                     Some(creds) => stream.next().now_or_never().flatten().unwrap_or(creds),
-                    None => stream.next().await.unwrap(),
+                    // librespot also ends the stream on zeroconf errors, without reporting them
+                    None => stream
+                        .next()
+                        .await
+                        .ok_or_else(|| eyre!("Discovery stopped without providing credentials."))
+                        .with_suggestion(|| {
+                            "Check the log for zeroconf errors, or log in with \
+                             `spotifyd authenticate` so that spotifyd doesn't depend on discovery."
+                        })?,
                 };
                 *last_credentials = Some(new_creds.clone());
-                new_creds
+                Ok(new_creds)
             }
-            CredentialsProvider::CredentialsOnly(creds) => creds.clone(),
+            CredentialsProvider::CredentialsOnly(creds) => Ok(creds.clone()),
         }
     }
 
@@ -102,8 +112,8 @@ struct ConnectionInfo<SpircTask: Future<Output = ()>> {
 impl MainLoop {
     async fn get_connection(
         &mut self,
-    ) -> Result<ConnectionInfo<impl Future<Output = ()> + use<>>, Error> {
-        let creds = self.credentials_provider.get_credentials().await;
+    ) -> eyre::Result<ConnectionInfo<impl Future<Output = ()> + use<>>> {
+        let creds = self.credentials_provider.get_credentials().await?;
 
         let mut connection_backoff = Backoff::default();
         loop {
@@ -146,7 +156,7 @@ impl MainLoop {
                 }
                 Err(err) => {
                     let Ok(backoff) = connection_backoff.next_backoff() else {
-                        break Err(err);
+                        break Err(err.into());
                     };
                     error!("connection to spotify failed: {err}");
                     info!(


### PR DESCRIPTION
`spotifyd` panics with a bare `Option::unwrap()` when the zeroconf responder fails to come up. My service sat in a systemd restart loop with nothing but this in the journal:

```text
spotifyd[1029740]: The application panicked (crashed).
spotifyd[1029740]: Message:  called `Option::unwrap()` on a `None` value
spotifyd[1029740]: Location: src/main_loop.rs:244
systemd[1]: spotifyd.service: Main process exited, code=exited, status=101/n/a
systemd[1]: spotifyd.service: Scheduled restart job, restart counter is at 78.
```

The cause was `net.ipv4.igmp_max_memberships`, default 20, against the 27 interfaces carrying addresses on this box (docker, tailscale, a pile of emulator taps). libmdns gives up joining the multicast group, and spotifyd dies two lines later:

```text
[INFO] Starting zeroconf server to advertise on local network.
[ERROR] libmdns error: Setting up dns-sd failed: No buffer space available (os error 105)
The application panicked (crashed).
Message:  called `Option::unwrap()` on a `None` value
Location: src/main_loop.rs:52
```

(`:52` is current master, `:244` is the same code in 0.4.1.)

librespot does report the failure, we just never see it. `launch_libmdns` logs it and pushes it into the event channel ([`discovery/src/lib.rs#L418-L421`](https://github.com/librespot-org/librespot/blob/d36f9f1907e8cc9d68a93f8ebc6b627b1bf7267d/discovery/src/lib.rs#L418-L421)):

```rust
        if let Err(e) = inner() {
            log::error!("libmdns error: {e}");
            let _ = status_tx.send(DiscoveryEvent::ZeroconfError(e));
        }
```

The `Stream` impl then turns that into end-of-stream, since `Item` is `Credentials` and there's nowhere to put an error ([`discovery/src/lib.rs#L539-L553`](https://github.com/librespot-org/librespot/blob/d36f9f1907e8cc9d68a93f8ebc6b627b1bf7267d/discovery/src/lib.rs#L539-L553)):

```rust
impl Stream for Discovery {
    type Item = Credentials;

    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
        match Pin::new(&mut self.event_rx).poll_recv(cx) {
            // Yields credentials
            Poll::Ready(Some(DiscoveryEvent::Credentials(creds))) => Poll::Ready(Some(creds)),
            // Also terminate the stream on fatal server or MDNS/DNS-SD errors.
            Poll::Ready(Some(
                DiscoveryEvent::ServerError(_) | DiscoveryEvent::ZeroconfError(_),
            )) => Poll::Ready(None),
```

All of it happens inside `spawn_blocking`, long after `launch()` handed us an `Ok`, so the retry loop in `setup.rs` never gets a chance either.

`None` here means "no credentials, ever", not "shutting down". Handling it gives:

```text
Error:
   0: failed to connect to spotify
   1: Discovery stopped without providing credentials.

Suggestion: Check the log for zeroconf errors, or log in with `spotifyd authenticate` so that spotifyd doesn't depend on discovery.
```

Only a discovery-only start with no cached credentials reaches that branch. With credentials present, `get_credentials` takes the non-blocking arm and behaves as before.
