### PR TITLE
discovery: allow limiting the advertised ip addresses

### DIFF
--- a/contrib/spotifyd.conf
+++ b/contrib/spotifyd.conf
@@ -56,6 +56,10 @@
 # zeroconf port need to be allowed through any active firewall.
 #zeroconf_port = 1234
 
+# The ip addresses that `spotifyd` advertises via mDNS. By default, the addresses
+# of all interfaces are advertised.
+#zeroconf_ip = ["192.168.0.10"]
+
 #-------#
 # AUDIO #
 #-------#

--- a/docs/src/configuration/auth.md
+++ b/docs/src/configuration/auth.md
@@ -11,6 +11,8 @@ For this to work, you need to make sure that your firewall isn't blocking the di
 - `5353 UDP`: MDNS service advertisement
 - A zeroconf port which uses TCP. By default, it is randomly chosen, but if you want to, you can configure it with the `--zeroconf-port` cli option / `zeroconf_port` config value.
 
+By default, `spotifyd` advertises the addresses of all interfaces. On hosts with many of them, clients may pick one that they cannot reach, in which case you can limit the advertisement with the `--zeroconf-ip` cli option / `zeroconf_ip` config value.
+
 If you don't want discovery, because you're using one of the methods below, you can disable it via the `--disable-discovery` cli option / `disable_discovery = true` config value.
 
 > __Note:__ By default, the last active session will be remembered and reconnected once the service is restarted.

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ use std::{
     borrow::Cow,
     convert::TryInto,
     fs,
+    net::IpAddr,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -339,6 +340,10 @@ pub struct SharedConfigValues {
     #[arg(long)]
     zeroconf_port: Option<u16>,
 
+    /// The ip addresses to advertise for the Spotify Connect discovery
+    #[arg(long, value_name = "IP", value_delimiter = ',')]
+    zeroconf_ip: Option<Vec<IpAddr>>,
+
     /// The proxy used to connect to spotify's servers
     #[arg(long, value_name = "URL")]
     proxy: Option<String>,
@@ -583,6 +588,7 @@ impl SharedConfigValues {
             on_song_change_hook,
             disable_discovery,
             zeroconf_port,
+            zeroconf_ip,
             proxy,
             device_type,
             max_cache_size,
@@ -634,6 +640,7 @@ pub(crate) struct SpotifydConfig {
     pub(crate) shell: String,
     pub(crate) discovery: bool,
     pub(crate) zeroconf_port: Option<u16>,
+    pub(crate) zeroconf_ip: Option<Vec<IpAddr>>,
     pub(crate) device_type: LSDeviceType,
     #[cfg(feature = "dbus_mpris")]
     pub(crate) mpris: MprisConfig,
@@ -757,6 +764,7 @@ pub(crate) fn get_internal_config(config: CliConfig) -> SpotifydConfig {
         shell,
         discovery: !config.shared_config.disable_discovery.unwrap_or(false),
         zeroconf_port: config.shared_config.zeroconf_port,
+        zeroconf_ip: config.shared_config.zeroconf_ip,
         device_type,
         #[cfg(unix)]
         pid,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -76,6 +76,7 @@ pub(crate) fn initial_state(
     let backend = config.backend.clone();
 
     let zeroconf_port = config.zeroconf_port.unwrap_or(0);
+    let zeroconf_ip = config.zeroconf_ip.unwrap_or_default();
 
     let creds = if let Some(creds) = config.oauth_cache.as_ref().and_then(|c| c.credentials()) {
         info!(
@@ -105,6 +106,7 @@ pub(crate) fn initial_state(
             .name(config.device_name.clone())
             .device_type(config.device_type)
             .port(zeroconf_port)
+            .zeroconf_ip(zeroconf_ip.clone())
             .launch()
             {
                 Ok(discovery_stream) => break Some(discovery_stream),


### PR DESCRIPTION
The mDNS responder advertises an A record for every interface, because spotifyd never fills in the `zeroconf_ip` list that librespot's builder has been offering all along: [`Builder::zeroconf_ip`](https://github.com/librespot-org/librespot/blob/d36f9f1907e8cc9d68a93f8ebc6b627b1bf7267d/discovery/src/lib.rs#L481-L485).

On a box with docker, tailscale and a dozen emulator taps, clients pick whichever record they like. Mine kept landing on a 192.168.94.x tap address that nothing on the LAN can reach.

`--zeroconf-ip 10.0.0.5` / `zeroconf_ip = ["10.0.0.5"]` limits what goes out. Plumbed the same way as `zeroconf_port`.

#990 asked for this back in 2021 and stalled on the conclusion that librespot was in the way, "Zeroconf discovery is hardcoded to bind to `0.0.0.0`", with a later comment: "I would like to use a specific bind ip. With multiple IP addresses on one machine, this is a critical need." That was accurate then. The builder method exists now and nothing on our side was calling it. #1285 is the adjacent report, where a second IPv4 on one interface breaks discovery and removing it brings the device back.

This closes neither of them. libmdns applies the list when it builds answer records and nowhere else: [`fsm.rs#L244`](https://github.com/librespot-org/libmdns/blob/7a655cf8cf16bff7da78bdc1b9d29561443b8994/src/fsm.rs#L244-L247). The socket still binds `ANY_ADDR` and still joins the multicast group on every non-loopback interface: [`address_family.rs#L26`](https://github.com/librespot-org/libmdns/blob/7a655cf8cf16bff7da78bdc1b9d29561443b8994/src/address_family.rs#L26-L38). The discovery TCP listener is untouched. The bind half of #990 and the failure in #1285 both stay open.
